### PR TITLE
Bump Clogistic to sklearn 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
+.idea/
 lib/
 lib64/
 parts/

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Dependencies
 
 * cvxpy>=1.4.0
 * numpy>=1.26.4
-* scikit-learn>=1.5.0
+* scikit-learn>=1.2.0
 * scipy>=1.12.0
 
 

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ in this case, it is unconstrained.
 L2-norm with bounds
 -------------------
 
-If we choose ``penalty="l2"`` or ``penalty="none"``, the L-BFGS-B solver can handle bound constraints.
+If we choose ``penalty="l2"`` or ``penalty=None``, the L-BFGS-B solver can handle bound constraints.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,10 @@ To install from source, download or clone the git repository
 Dependencies
 ------------
 
-* cvxpy>=1.0.31
-* numpy
-* scikit-learn>=0.20.0
-* scipy
+* cvxpy>=1.4.0
+* numpy>=1.26.4
+* scikit-learn>=1.5.0
+* scipy>=1.12.0
 
 
 Examples
@@ -53,23 +53,23 @@ clogistic can flawlessly replace the scikit-learn LogisticRegression import when
 .. code-block:: python
    
    # from sklearn.linear_models import LogisticRegression
-   from clogistic import LogisticRegression
+   from clogistic import ConstrainedLogisticRegression as LogisticRegression
 
 
 L1-norm / Elastic-Net
 ---------------------
 
-In the unconstrained problem, the L-BFGS-B solver supports both L1 and Elastic-Net regularization.
+In the unconstrained problem, the lbfgs solver supports both L1 and Elastic-Net regularization.
 
 .. code-block:: python
 
-   >>> from clogistic import LogisticRegression
+   >>> from clogistic import LogisticRegression as LogisticRegression
    >>> from sklearn.datasets import load_breast_cancer
    >>> X, y = load_breast_cancer(return_X_y=True)
-   >>> clf = LogisticRegression(solver="L-BFGS-B", penalty="l1")
+   >>> clf = LogisticRegression(solver="lbfgs", penalty="l1")
    >>> clf.fit(X, y)
    LogisticRegression(C=1.0, class_weight=None, fit_intercept=True, l1_ratio=None,
-                      max_iter=100, penalty='l1', solver='L-BFGS-B', tol=0.0001,
+                      max_iter=100, penalty='l1', solver='lbfgs', tol=0.0001,
                       verbose=False, warm_start=False)
    >>> clf.predict(X[:5, :])
    array([0, 0, 0, 1, 0])
@@ -93,10 +93,10 @@ In the unconstrained problem, the L-BFGS-B solver supports both L1 and Elastic-N
 
 .. code-block:: python
 
-   >>> clf = LogisticRegression(solver="L-BFGS-B", penalty="elasticnet", l1_ratio=0.5)
+   >>> clf = LogisticRegression(solver="lbfgs", penalty="elasticnet", l1_ratio=0.5)
    >>> clf.fit(X, y)
    LogisticRegression(C=1.0, class_weight=None, fit_intercept=True, l1_ratio=0.5,
-                      max_iter=100, penalty='elasticnet', solver='L-BFGS-B',
+                      max_iter=100, penalty='elasticnet', solver='lbfgs',
                       tol=0.0001, verbose=False, warm_start=False)
    >>> clf.score(X, y)
    0.9402460456942003
@@ -145,10 +145,10 @@ If we choose ``penalty="l2"`` or ``penalty=None``, the L-BFGS-B solver can handl
 
 .. code-block:: python
 
-   >>> clf = LogisticRegression(solver="L-BFGS-B", penalty="l2")
+   >>> clf = LogisticRegression(solver="lbfgs", penalty="l2")
    >>> clf.fit(X, y, bounds=bounds)
    LogisticRegression(C=1.0, class_weight=None, fit_intercept=True, l1_ratio=None,
-                      max_iter=100, penalty='l2', solver='L-BFGS-B', tol=0.0001,
+                      max_iter=100, penalty='l2', solver='lbfgs', tol=0.0001,
                       verbose=False, warm_start=False)
    >>> clf.score(X, y, bounds=bounds)
    0.9507908611599297

--- a/clogistic/__init__.py
+++ b/clogistic/__init__.py
@@ -2,5 +2,7 @@ from .__version__ import __version__
 from .clogistic import LogisticRegression
 
 
-__all__ = ['__version__',
-           'LogisticRegression']
+__all__ = [
+    "__version__",
+    "LogisticRegression",
+]

--- a/clogistic/__init__.py
+++ b/clogistic/__init__.py
@@ -1,8 +1,8 @@
 from .__version__ import __version__
-from .clogistic import LogisticRegression
+from .clogistic import ConstrainedLogisticRegression
 
 
 __all__ = [
     "__version__",
-    "LogisticRegression",
+    "ConstrainedLogisticRegression",
 ]

--- a/clogistic/__init__.py
+++ b/clogistic/__init__.py
@@ -1,4 +1,4 @@
-from ._version import __version__
+from .__version__ import __version__
 from .clogistic import LogisticRegression
 
 

--- a/clogistic/__version__.py
+++ b/clogistic/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -32,49 +32,68 @@ from sklearn.utils.validation import check_X_y
 from sklearn.utils.validation import _check_sample_weight
 
 
-def _check_parameters(penalty, tol, C, fit_intercept, class_weight, solver,
-                      max_iter, l1_ratio, warm_start, verbose):
+def _check_parameters(
+    penalty,
+    tol,
+    C,
+    fit_intercept,
+    class_weight,
+    solver,
+    max_iter,
+    l1_ratio,
+    warm_start,
+    verbose,
+):
 
     if penalty not in ("l1", "l2", "elasticnet", "none"):
-        raise ValueError('Invalid value for penalty. Supported penalties are '
-                         '"l1", "l2", "elasticnet" and "none".')
+        raise ValueError(
+            "Invalid value for penalty. Supported penalties are "
+            '"l1", "l2", "elasticnet" and "none".'
+        )
 
     if penalty == "elasticnet":
-        if (not isinstance(l1_ratio, numbers.Number) or
-                not 0 <= l1_ratio <= 1):
-            raise ValueError("l1_ratio must be between 0 and 1; got {}."
-                             .format(l1_ratio))
+        if not isinstance(l1_ratio, numbers.Number) or not 0 <= l1_ratio <= 1:
+            raise ValueError(
+                "l1_ratio must be between 0 and 1; got {}.".format(l1_ratio)
+            )
     elif l1_ratio is not None:
-        warnings.warn("l1_ratio parameter is only used when penalty is "
-                      "'elasticnet'; got penalty={}.".format(penalty))
+        warnings.warn(
+            "l1_ratio parameter is only used when penalty is "
+            "'elasticnet'; got penalty={}.".format(penalty)
+        )
 
     if not isinstance(tol, numbers.Number) or tol < 0:
-        raise ValueError("tol parameter for stopping criteria must be "
-                         "positive; got {}.".format(tol))
+        raise ValueError(
+            "tol parameter for stopping criteria must be "
+            "positive; got {}.".format(tol)
+        )
 
     if not isinstance(fit_intercept, bool):
-        raise TypeError("fit_intercept must be a bool; got {}."
-                        .format(fit_intercept))
+        raise TypeError("fit_intercept must be a bool; got {}.".format(fit_intercept))
 
     if class_weight is not None:
         if not isinstance(class_weight, (dict, str)):
-            raise TypeError('class_weight must be dict, "balanced" or None; '
-                            'got {}.'.format(class_weight))
+            raise TypeError(
+                'class_weight must be dict, "balanced" or None; '
+                "got {}.".format(class_weight)
+            )
 
         elif isinstance(class_weight, str) and class_weight != "balanced":
-            raise ValueError('Invalid value for class_weight. Allowed string '
-                             'value is "balanced".')
+            raise ValueError(
+                "Invalid value for class_weight. Allowed string " 'value is "balanced".'
+            )
 
     if solver not in ("ecos", "L-BFGS-B", "scs"):
-        raise ValueError('Invalid value for solver. Allowed string '
-                         'values are "ecos", "L-BFGS-B" and "scs".')
+        raise ValueError(
+            "Invalid value for solver. Allowed string "
+            'values are "ecos", "L-BFGS-B" and "scs".'
+        )
 
     if not isinstance(max_iter, numbers.Number) or max_iter < 0:
         raise ValueError("max_iter must be positive; got {}.".format(max_iter))
 
     if not isinstance(warm_start, bool):
-        raise TypeError("warm_start must be a bool; got {}."
-                        .format(warm_start))
+        raise TypeError("warm_start must be a bool; got {}.".format(warm_start))
 
     if not isinstance(verbose, bool):
         raise TypeError("verbose must be a bool; got {}.".format(verbose))
@@ -83,18 +102,23 @@ def _check_parameters(penalty, tol, C, fit_intercept, class_weight, solver,
 def _check_solver(solver, penalty, bounds, constraints, warm_start):
     if solver == "L-BFGS-B":
         if penalty in ("l1", "elasticnet") and bounds is not None:
-            raise ValueError('Solver "L-BFGS-B" does not support bound '
-                             'constraints with penalty "l1" and '
-                             '"elasticnet"; choose either "ecos" or "scs" '
-                             'solver.')
+            raise ValueError(
+                'Solver "L-BFGS-B" does not support bound '
+                'constraints with penalty "l1" and '
+                '"elasticnet"; choose either "ecos" or "scs" '
+                "solver."
+            )
 
         if constraints is not None:
-            raise ValueError('"L-BFGS-B" solver does not  supports linear '
-                             'constraints.')
+            raise ValueError(
+                '"L-BFGS-B" solver does not  supports linear ' "constraints."
+            )
 
         if penalty in ("l1", "elasticnet") and warm_start:
-            raise ValueError('Solver "L-BFGS-B" does not support warm start '
-                             'with "l1" and "elasticnet" regularization.')
+            raise ValueError(
+                'Solver "L-BFGS-B" does not support warm start '
+                'with "l1" and "elasticnet" regularization.'
+            )
 
 
 def _check_X_y(X, y):
@@ -103,11 +127,13 @@ def _check_X_y(X, y):
 
     classes = np.unique(y)
     if len(classes) < 2:
-        raise ValueError("This solver needs samples of 2 classes"
-                         " in the data, but the data contains only one"
-                         " class: {}.".format(classes[0]))
+        raise ValueError(
+            "This solver needs samples of 2 classes"
+            " in the data, but the data contains only one"
+            " class: {}.".format(classes[0])
+        )
 
-    X, y = check_X_y(X, y, accept_sparse='csr', order="C")
+    X, y = check_X_y(X, y, accept_sparse="csr", order="C")
     return X, y, classes
 
 
@@ -120,14 +146,17 @@ def _check_bounds(bounds, n, fit_intercept):
     check_consistent_length(lb, ub)
 
     if n + int(fit_intercept) != len(lb):
-        raise ValueError("Length of lower bounds is incorrect; got {} and "
-                         "must be {}.".format(len(lb), n + int(fit_intercept)))
+        raise ValueError(
+            "Length of lower bounds is incorrect; got {} and "
+            "must be {}.".format(len(lb), n + int(fit_intercept))
+        )
 
 
 def _check_constraints(constraints, n, fit_intercept):
     if not isinstance(constraints, LinearConstraint):
-        raise TypeError("constraints is not of type "
-                        "scipy.optimize.LinearConstraint.")
+        raise TypeError(
+            "constraints is not of type " "scipy.optimize.LinearConstraint."
+        )
 
     A = constraints.A
     lb = constraints.lb
@@ -135,22 +164,24 @@ def _check_constraints(constraints, n, fit_intercept):
     check_consistent_length(lb, ub)
 
     if n + int(fit_intercept) != A.shape[1]:
-        raise ValueError("Number of columns of matrix A is incorrect; got {} "
-                         "and must be {}.".format(A.shape[1],
-                                                  n + int(fit_intercept)))
+        raise ValueError(
+            "Number of columns of matrix A is incorrect; got {} "
+            "and must be {}.".format(A.shape[1], n + int(fit_intercept))
+        )
 
     check_consistent_length(A, lb)
 
 
-def _logistic_l1_loss_and_grad(w2, X, y, alpha, penalty, fit_intercept,
-                               l1_ratio, sample_weight):
+def _logistic_l1_loss_and_grad(
+    w2, X, y, alpha, penalty, fit_intercept, l1_ratio, sample_weight
+):
 
     n_samples, n_features = X.shape
 
     grad = np.empty_like(w2)
     reg_grad = np.zeros(w2.size)
 
-    c = 0.
+    c = 0.0
     if fit_intercept:
         c = w2[-1]
         w = w2[:n_features] - w2[n_features:-1]
@@ -171,7 +202,7 @@ def _logistic_l1_loss_and_grad(w2, X, y, alpha, penalty, fit_intercept,
         reg = regl2 + regl1
         rg1 = alpha * l1_ratio
         rg2 = alpha * (1 - l1_ratio) * w
-        reg_grad[:2*n_features] = np.concatenate([rg2, -rg2]) + rg1
+        reg_grad[: 2 * n_features] = np.concatenate([rg2, -rg2]) + rg1
 
     out = -np.sum(sample_weight * log_logistic(yz)) + reg
 
@@ -193,13 +224,12 @@ def _logistic_l1_loss_and_grad(w2, X, y, alpha, penalty, fit_intercept,
     return out, grad
 
 
-def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept,
-                            sample_weight):
+def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept, sample_weight):
 
     n_samples, n_features = X.shape
     grad = np.empty_like(w)
 
-    c = 0.
+    c = 0.0
     if fit_intercept:
         c = w[-1]
         w = w[:-1]
@@ -208,7 +238,7 @@ def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept,
     yz = y * z
 
     if penalty == "l2":
-        reg = .5 * alpha * np.dot(w, w)
+        reg = 0.5 * alpha * np.dot(w, w)
         reg_grad = alpha * w
     else:
         reg = 0
@@ -226,25 +256,36 @@ def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept,
     return out, grad
 
 
-def _fit_lbfgsb(penalty, tol, C, fit_intercept, max_iter, l1_ratio,
-                warm_start_coef, verbose, X, y, sample_weight, bounds=None):
+def _fit_lbfgsb(
+    penalty,
+    tol,
+    C,
+    fit_intercept,
+    max_iter,
+    l1_ratio,
+    warm_start_coef,
+    verbose,
+    X,
+    y,
+    sample_weight,
+    bounds=None,
+):
 
     m, n = X.shape
 
-    mask = (y == 1)
+    mask = y == 1
     y_bin = np.ones(y.shape, dtype=X.dtype)
-    y_bin[~mask] = -1.
+    y_bin[~mask] = -1.0
 
     if penalty in ("l1", "elasticnet"):
         func = _logistic_l1_loss_and_grad
         w0 = np.zeros(2 * n + int(fit_intercept))
-        bounds = [(0, np.inf)] * n*2 + [(-np.inf, np.inf)] * int(fit_intercept)
-        args = (X, y_bin, 1. / C, penalty, fit_intercept, l1_ratio,
-                sample_weight)
+        bounds = [(0, np.inf)] * n * 2 + [(-np.inf, np.inf)] * int(fit_intercept)
+        args = (X, y_bin, 1.0 / C, penalty, fit_intercept, l1_ratio, sample_weight)
     else:
         func = _logistic_loss_and_grad
         w0 = np.zeros(n + int(fit_intercept))
-        args = (X, y_bin, 1. / C, penalty, fit_intercept, sample_weight)
+        args = (X, y_bin, 1.0 / C, penalty, fit_intercept, sample_weight)
 
     if warm_start_coef is not None:
         w0 = warm_start_coef
@@ -252,8 +293,8 @@ def _fit_lbfgsb(penalty, tol, C, fit_intercept, max_iter, l1_ratio,
     options = {"disp": verbose, "gtol": tol, "maxiter": max_iter}
 
     res = minimize(
-        func, w0, method="L-BFGS-B", jac=True,
-        bounds=bounds, args=args, options=options)
+        func, w0, method="L-BFGS-B", jac=True, bounds=bounds, args=args, options=options
+    )
 
     if fit_intercept:
         intercept_ = res.x[-1]
@@ -271,9 +312,22 @@ def _fit_lbfgsb(penalty, tol, C, fit_intercept, max_iter, l1_ratio,
     return coef_, intercept_
 
 
-def _fit_cvxpy(solver, penalty, tol, C, fit_intercept, max_iter, l1_ratio,
-               warm_start_coef, verbose, X, y, sample_weight, bounds=None,
-               constraints=None):
+def _fit_cvxpy(
+    solver,
+    penalty,
+    tol,
+    C,
+    fit_intercept,
+    max_iter,
+    l1_ratio,
+    warm_start_coef,
+    verbose,
+    X,
+    y,
+    sample_weight,
+    bounds=None,
+    constraints=None,
+):
 
     m, n = X.shape
 
@@ -288,8 +342,7 @@ def _fit_cvxpy(solver, penalty, tol, C, fit_intercept, max_iter, l1_ratio,
         Xbeta = X @ beta
 
     # Objective function
-    log_likelihood = C * sample_weight @ (
-        cp.multiply(y, Xbeta) - cp.logistic(Xbeta))
+    log_likelihood = C * sample_weight @ (cp.multiply(y, Xbeta) - cp.logistic(Xbeta))
 
     # Bounds
     cons = []
@@ -347,12 +400,13 @@ def _fit_cvxpy(solver, penalty, tol, C, fit_intercept, max_iter, l1_ratio,
     problem = cp.Problem(obj, cons)
 
     if solver == "ecos":
-        solve_options = {'solver': cp.ECOS, 'abstol': tol}
+        solve_options = {"solver": cp.ECOS, "abstol": tol}
     elif solver == "scs":
-        solve_options = {'solver': cp.SCS, 'eps': tol}
+        solve_options = {"solver": cp.SCS, "eps": tol}
 
-    problem.solve(max_iters=max_iter, verbose=verbose, warm_start=warm_start,
-                  **solve_options)
+    problem.solve(
+        max_iters=max_iter, verbose=verbose, warm_start=warm_start, **solve_options
+    )
 
     if fit_intercept:
         intercept_ = beta.value[-1]
@@ -364,8 +418,7 @@ def _fit_cvxpy(solver, penalty, tol, C, fit_intercept, max_iter, l1_ratio,
     return coef_, intercept_
 
 
-class LogisticRegression(BaseEstimator, LinearClassifierMixin,
-                         SparseCoefMixin):
+class LogisticRegression(BaseEstimator, LinearClassifierMixin, SparseCoefMixin):
     """
     Constrained Logistic Regression (aka logit, MaxEnt) classifier.
 
@@ -453,9 +506,20 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         Ciyou Zhu, Richard Byrd, Jorge Nocedal and Jose Luis Morales.
         http://users.iems.northwestern.edu/~nocedal/L-BFGS-Bb.html
     """
-    def __init__(self, penalty="l2", tol=1e-4, C=1.0, fit_intercept=True,
-                 class_weight=None, solver="ecos", max_iter=100, l1_ratio=None,
-                 warm_start=False, verbose=False):
+
+    def __init__(
+        self,
+        penalty="l2",
+        tol=1e-4,
+        C=1.0,
+        fit_intercept=True,
+        class_weight=None,
+        solver="ecos",
+        max_iter=100,
+        l1_ratio=None,
+        warm_start=False,
+        verbose=False,
+    ):
 
         self.penalty = penalty
         self.tol = tol
@@ -498,8 +562,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         """
         _check_parameters(**self.get_params())
 
-        _check_solver(self.solver, self.penalty, bounds, constraints,
-                      self.warm_start)
+        _check_solver(self.solver, self.penalty, bounds, constraints, self.warm_start)
 
         X, y, self.classes_ = _check_X_y(X, y)
 
@@ -517,29 +580,51 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         if self.class_weight is not None:
             le = LabelEncoder()
             class_weight_ = compute_class_weight(
-                class_weight=self.class_weight, classes=self.classes_, y=y)
+                class_weight=self.class_weight, classes=self.classes_, y=y
+            )
             sample_weight *= class_weight_[le.fit_transform(y)]
 
         if self.warm_start:
-            warm_start_coef = getattr(self, 'coef_', None)
+            warm_start_coef = getattr(self, "coef_", None)
         else:
             warm_start_coef = None
         if warm_start_coef is not None and self.fit_intercept:
-            warm_start_coef = np.append(warm_start_coef,
-                                        self.intercept_[:, np.newaxis],
-                                        axis=1)
+            warm_start_coef = np.append(
+                warm_start_coef, self.intercept_[:, np.newaxis], axis=1
+            )
 
         if self.solver in ("ecos", "scs"):
             coef_, intercept_ = _fit_cvxpy(
-                self.solver, self.penalty, self.tol, self.C,
-                self.fit_intercept, self.max_iter, self.l1_ratio,
-                warm_start_coef, self.verbose, X, y, sample_weight, bounds,
-                constraints)
+                self.solver,
+                self.penalty,
+                self.tol,
+                self.C,
+                self.fit_intercept,
+                self.max_iter,
+                self.l1_ratio,
+                warm_start_coef,
+                self.verbose,
+                X,
+                y,
+                sample_weight,
+                bounds,
+                constraints,
+            )
         else:
             coef_, intercept_ = _fit_lbfgsb(
-                self.penalty, self.tol, self.C, self.fit_intercept,
-                self.max_iter, self.l1_ratio, warm_start_coef, self.verbose,
-                X, y, sample_weight, bounds)
+                self.penalty,
+                self.tol,
+                self.C,
+                self.fit_intercept,
+                self.max_iter,
+                self.l1_ratio,
+                warm_start_coef,
+                self.verbose,
+                X,
+                y,
+                sample_weight,
+                bounds,
+            )
 
         self.coef_ = np.asarray([coef_])
         self.intercept_ = np.asarray([intercept_])

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -17,83 +17,16 @@ import cvxpy as cp
 import numpy as np
 from scipy.optimize import Bounds, LinearConstraint, minimize
 from scipy.special import expit
-from sklearn.base import BaseEstimator
-from sklearn.linear_model._base import LinearClassifierMixin, SparseCoefMixin
+from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_consistent_length, compute_class_weight
 from sklearn.utils.extmath import log_logistic, safe_sparse_dot
 from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import _check_sample_weight, check_X_y, check_is_fitted
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted
+from sklearn.utils._param_validation import StrOptions, Interval
 
 
-def _check_parameters(
-    penalty,
-    tol,
-    C,
-    fit_intercept,
-    class_weight,
-    solver,
-    max_iter,
-    l1_ratio,
-    warm_start,
-    verbose,
-):
-
-    if penalty not in ("l1", "l2", "elasticnet", "none"):
-        raise ValueError(
-            "Invalid value for penalty. Supported penalties are "
-            '"l1", "l2", "elasticnet" and "none".'
-        )
-
-    if penalty == "elasticnet":
-        if not isinstance(l1_ratio, numbers.Number) or not 0 <= l1_ratio <= 1:
-            raise ValueError(
-                "l1_ratio must be between 0 and 1; got {}.".format(l1_ratio)
-            )
-    elif l1_ratio is not None:
-        warnings.warn(
-            "l1_ratio parameter is only used when penalty is "
-            "'elasticnet'; got penalty={}.".format(penalty)
-        )
-
-    if not isinstance(tol, numbers.Number) or tol < 0:
-        raise ValueError(
-            "tol parameter for stopping criteria must be "
-            "positive; got {}.".format(tol)
-        )
-
-    if not isinstance(fit_intercept, bool):
-        raise TypeError("fit_intercept must be a bool; got {}.".format(fit_intercept))
-
-    if class_weight is not None:
-        if not isinstance(class_weight, (dict, str)):
-            raise TypeError(
-                'class_weight must be dict, "balanced" or None; '
-                "got {}.".format(class_weight)
-            )
-
-        elif isinstance(class_weight, str) and class_weight != "balanced":
-            raise ValueError(
-                "Invalid value for class_weight. Allowed string " 'value is "balanced".'
-            )
-
-    if solver not in ("ecos", "L-BFGS-B", "scs"):
-        raise ValueError(
-            "Invalid value for solver. Allowed string "
-            'values are "ecos", "L-BFGS-B" and "scs".'
-        )
-
-    if not isinstance(max_iter, numbers.Number) or max_iter < 0:
-        raise ValueError("max_iter must be positive; got {}.".format(max_iter))
-
-    if not isinstance(warm_start, bool):
-        raise TypeError("warm_start must be a bool; got {}.".format(warm_start))
-
-    if not isinstance(verbose, bool):
-        raise TypeError("verbose must be a bool; got {}.".format(verbose))
-
-
-def _check_solver(solver, penalty, bounds, constraints, warm_start):
+def _check_solver(solver, penalty, bounds, constraints, warm_start, l1_ratio):
     if solver == "L-BFGS-B":
         if penalty in ("l1", "elasticnet") and bounds is not None:
             raise ValueError(
@@ -114,21 +47,16 @@ def _check_solver(solver, penalty, bounds, constraints, warm_start):
                 'with "l1" and "elasticnet" regularization.'
             )
 
-
-def _check_X_y(X, y):
-    if type_of_target(y) != "binary":
-        raise ValueError("This solver needs a binary target.")
-
-    classes = np.unique(y)
-    if len(classes) < 2:
-        raise ValueError(
-            "This solver needs samples of 2 classes"
-            " in the data, but the data contains only one"
-            " class: {}.".format(classes[0])
+    if penalty == "elasticnet":
+        if not isinstance(l1_ratio, numbers.Number) or not 0 <= l1_ratio <= 1:
+            raise ValueError(
+                "l1_ratio must be between 0 and 1; got {}.".format(l1_ratio)
+            )
+    elif l1_ratio is not None:
+        warnings.warn(
+            "l1_ratio parameter is only used when penalty is "
+            "'elasticnet'; got penalty={}.".format(penalty)
         )
-
-    X, y = check_X_y(X, y, accept_sparse="csr", order="C")
-    return X, y, classes
 
 
 def _check_bounds(bounds, n, fit_intercept):
@@ -287,7 +215,7 @@ def _fit_lbfgsb(
     options = {"disp": verbose, "gtol": tol, "maxiter": max_iter}
 
     res = minimize(
-        func, w0, method="L-BFGS-B", jac=True, bounds=bounds, args=args, options=options
+        func, w0.flatten(), method="L-BFGS-B", jac=True, bounds=bounds, args=args, options=options
     )
 
     if fit_intercept:
@@ -412,9 +340,7 @@ def _fit_cvxpy(
     return coef_, intercept_
 
 
-class ConstrainedLogisticRegression(
-    BaseEstimator, LinearClassifierMixin, SparseCoefMixin
-):
+class ConstrainedLogisticRegression(LogisticRegression):
     """
     Constrained Logistic Regression (aka logit, MaxEnt) classifier.
 
@@ -460,7 +386,7 @@ class ConstrainedLogisticRegression(
         Algorithm/solver to use in the optimization problem.
 
         - Unconstrained 'L-BFGS-B' handles all regularizations.
-        - Bound constrainted 'L-BFGS-B' handles L2 or no penalty.
+        - Bound constrained 'L-BFGS-B' handles L2 or no penalty.
         - For other cases, use 'ecos' or 'scs'.
 
         Note that 'ecos' and 'scs' are general-purpose solvers called via
@@ -503,30 +429,47 @@ class ConstrainedLogisticRegression(
         http://users.iems.northwestern.edu/~nocedal/L-BFGS-Bb.html
     """
 
+    _parameter_constraints: dict = {
+        "penalty": [StrOptions({"l1", "l2", "elasticnet"}), None],
+        "tol": [Interval(numbers.Real, 0, None, closed="left")],
+        "C": [Interval(numbers.Real, 0, None, closed="right")],
+        "fit_intercept": ["boolean"],
+        "class_weight": [dict, StrOptions({"balanced"}), None],
+        "solver": [StrOptions({"ecos", "L-BFGS-B", "scs"})],
+        "max_iter": [Interval(numbers.Integral, 0, None, closed="left")],
+        "verbose": ["verbose"],
+        "warm_start": ["boolean"],
+        "l1_ratio": [Interval(numbers.Real, 0, 1, closed="both"), None],
+    }
+
     def __init__(
         self,
         penalty="l2",
+        *,
         tol=1e-4,
         C=1.0,
         fit_intercept=True,
         class_weight=None,
         solver="ecos",
         max_iter=100,
-        l1_ratio=None,
+        verbose=0,
         warm_start=False,
-        verbose=False,
+        l1_ratio=None,
+        **kwargs,
     ):
-
-        self.penalty = penalty
-        self.tol = tol
-        self.C = C
-        self.fit_intercept = fit_intercept
-        self.class_weight = class_weight
-        self.solver = solver
-        self.max_iter = max_iter
-        self.l1_ratio = l1_ratio
-        self.warm_start = warm_start
-        self.verbose = verbose
+        super().__init__(
+            penalty=penalty,
+            tol=tol,
+            C=C,
+            fit_intercept=fit_intercept,
+            class_weight=class_weight,
+            solver=solver,
+            max_iter=max_iter,
+            verbose=verbose,
+            warm_start=warm_start,
+            l1_ratio=l1_ratio,
+            **kwargs,
+        )
 
     def fit(self, X, y, sample_weight=None, bounds=None, constraints=None):
         """
@@ -556,14 +499,25 @@ class ConstrainedLogisticRegression(
         self
             Fitted estimator.
         """
-        _check_parameters(**self.get_params())
+        self._validate_params()
 
-        _check_solver(self.solver, self.penalty, bounds, constraints, self.warm_start)
+        _check_solver(self.solver, self.penalty, bounds, constraints, self.warm_start, self.l1_ratio)
 
-        X, y, self.classes_ = _check_X_y(X, y)
+        X, y = self._validate_data(X, y, accept_sparse="csr", order="C")
 
-        self.classes_ = np.unique(y)
+        if type_of_target(y) != "binary":
+            raise ValueError("This solver needs a binary target.")
+
         n_samples, n_features = X.shape
+        self.n_features_in_ = n_features
+        self.classes_ = np.unique(y)
+
+        if len(self.classes_) < 2:
+            raise ValueError(
+                "This solver needs samples of at least 2 classes"
+                " in the data, but the data contains only one"
+                " class: %r" % self.classes_[0]
+            )
 
         if bounds is not None:
             _check_bounds(bounds, n_features, self.fit_intercept)
@@ -624,54 +578,13 @@ class ConstrainedLogisticRegression(
 
         self.coef_ = np.asarray([coef_])
         self.intercept_ = np.asarray([intercept_])
+        self.n_iter_ = np.zeros((len(self.classes_),), dtype=np.int32)
 
         return self
 
-    def predict_proba(self, X):
-        """
-        Probability estimates.
-
-        The returned estimates for all classes are ordered by the
-        label of classes.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Vector to be scored, where `n_samples` is the number of samples and
-            `n_features` is the number of features.
-
-        Returns
-        -------
-        T : array-like of shape (n_samples, n_classes)
-            Returns the probability of the sample for each class in the model,
-            where classes are ordered as they are in ``self.classes_``.
-        """
+    def as_logistic_regression(self) -> LogisticRegression:
         check_is_fitted(self)
-
-        proba = np.empty((X.shape[0], 2))
-        p0 = expit(-self.decision_function(X))
-        proba[:, 0] = p0
-        proba[:, 1] = 1 - p0
-
-        return proba
-
-    def predict_log_proba(self, X):
-        """
-        Predict logarithm of probability estimates.
-
-        The returned estimates for all classes are ordered by the
-        label of classes.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Vector to be scored, where `n_samples` is the number of samples and
-            `n_features` is the number of features.
-
-        Returns
-        -------
-        T : array-like of shape (n_samples, n_classes)
-            Returns the log-probability of the sample for each class in the
-            model, where classes are ordered as they are in ``self.classes_``.
-        """
-        return np.log(self.predict_proba(X))
+        new = LogisticRegression()
+        for k, v in self.__dict__.items():
+            setattr(new, k, v)
+        return new

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -20,7 +20,7 @@ from scipy.special import expit
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_consistent_length, compute_class_weight
-from sklearn.utils.extmath import log_logistic, safe_sparse_dot
+from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 from sklearn.utils._param_validation import StrOptions, Interval
@@ -126,7 +126,7 @@ def _logistic_l1_loss_and_grad(
         rg2 = alpha * (1 - l1_ratio) * w
         reg_grad[: 2 * n_features] = np.concatenate([rg2, -rg2]) + rg1
 
-    out = -np.sum(sample_weight * log_logistic(yz)) + reg
+    out = np.sum(sample_weight * np.logaddexp(0, -yz)) + reg
 
     z = expit(yz)
     z0 = sample_weight * (z - 1) * y
@@ -166,7 +166,7 @@ def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept, sample_weigh
         reg = 0
         reg_grad = 0
 
-    out = -np.sum(sample_weight * log_logistic(yz)) + reg
+    out = np.sum(sample_weight * np.logaddexp(0, -yz)) + reg
 
     z = expit(yz)
     z0 = sample_weight * (z - 1) * y
@@ -327,7 +327,7 @@ def _fit_cvxpy(
         solve_options = {"solver": cp.SCS, "eps": tol}
 
     problem.solve(
-        max_iters=max_iter, verbose=verbose, warm_start=warm_start, **solve_options
+        max_iters=max_iter, verbose=bool(verbose), warm_start=warm_start, **solve_options
     )
 
     if fit_intercept:

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -16,8 +16,10 @@ from typing import Any, Literal, Optional, Union
 
 import cvxpy as cp
 import numpy as np
+import numpy.typing as npt
 from scipy.optimize import Bounds, LinearConstraint, minimize
 from scipy.special import expit
+from sklearn.base import BaseEstimator
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_consistent_length, compute_class_weight
@@ -41,6 +43,32 @@ except ImportError:
             return wrapper
 
         return decorator
+
+
+try:
+    from sklearn.utils.validation import validate_data
+
+except ImportError:
+    # sklearn.utils.validation.validate_data introduced
+    # in sklearn 1.6.0, clogistic supports sklearn>=1.2.0:
+    # this block is to support sklearn>=1.2.0,<1.6.0
+
+    def validate_data(
+        _estimator: BaseEstimator,
+        X: Union[npt.ArrayLike, Literal["no_validation"]] = "no_validation",
+        y: Union[npt.ArrayLike, Literal["no_validation"]] = "no_validation",
+        reset: bool = True,
+        validate_separately: Union[Literal[False], dict[str, Any]] = False,
+        skip_check_array: bool = False,
+        **check_params: Any,
+    ) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
+        return _estimator._validate_data(
+            X=X,
+            y=y,
+            reset=reset,
+            validate_separately=validate_separately,
+            **check_params,
+        )
 
 
 PenaltyType = Optional[Literal["l1", "l2", "elasticnet"]]
@@ -524,9 +552,9 @@ class ConstrainedLogisticRegression(LogisticRegression):
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(
         self,
-        X: np.ndarray,
-        y: np.ndarray,
-        sample_weight: Optional[np.ndarray] = None,
+        X: npt.ArrayLike,
+        y: npt.ArrayLike,
+        sample_weight: Optional[npt.ArrayLike] = None,
         bounds: Optional[Bounds] = None,
         constraints: Optional[LinearConstraint] = None,
     ) -> "ConstrainedLogisticRegression":
@@ -568,7 +596,7 @@ class ConstrainedLogisticRegression(LogisticRegression):
             l1_ratio=self.l1_ratio,
         )
 
-        X, y = self._validate_data(X, y, accept_sparse="csr", order="C")
+        X, y = validate_data(self, X, y, accept_sparse="csr", order="C")
 
         if type_of_target(y) != "binary":
             raise ValueError("This solver needs a binary target.")

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -495,7 +495,6 @@ class ConstrainedLogisticRegression(LogisticRegression):
         verbose: Union[int, bool] = 0,
         warm_start: bool = False,
         l1_ratio: Optional[float] = None,
-        **kwargs,
     ):
         super().__init__(
             penalty=penalty,
@@ -508,7 +507,6 @@ class ConstrainedLogisticRegression(LogisticRegression):
             verbose=verbose,
             warm_start=warm_start,
             l1_ratio=l1_ratio,
-            **kwargs,
         )
 
     def fit(

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -41,10 +41,8 @@ def _check_solver(
     if solver == "lbfgs":
         if penalty in ("l1", "elasticnet") and bounds is not None:
             raise ValueError(
-                'Solver "lbfgs" does not support bound '
-                'constraints with penalty "l1" and '
-                '"elasticnet"; choose either "ecos" or "scs" '
-                "solver."
+                "Solver 'lbfgs' does not support bound constraints with penalty "
+                "'l1' and 'elasticnet'; choose either 'ecos' or 'scs' solver."
             )
 
         if constraints is not None:
@@ -52,8 +50,8 @@ def _check_solver(
 
         if penalty in ("l1", "elasticnet") and warm_start:
             raise ValueError(
-                'Solver "lbfgs" does not support warm start '
-                'with "l1" and "elasticnet" regularization.'
+                "Solver 'lbfgs' does not support warm start with 'l1' "
+                "and 'elasticnet' regularization."
             )
 
     if penalty == "elasticnet":
@@ -63,8 +61,8 @@ def _check_solver(
             )
     elif l1_ratio is not None:
         warnings.warn(
-            "l1_ratio parameter is only used when penalty is "
-            "'elasticnet'; got penalty={}.".format(penalty)
+            "l1_ratio parameter is only used when penalty "
+            "is 'elasticnet'; got penalty={}.".format(penalty)
         )
 
 

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -21,10 +21,26 @@ from scipy.special import expit
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_consistent_length, compute_class_weight
+from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _check_sample_weight, check_is_fitted
-from sklearn.utils._param_validation import StrOptions, Interval
+
+try:
+    from sklearn.base import _fit_context
+except ImportError:
+    # _fit_context introduced in sklearn 1.3.0,
+    # clogistic supports sklearn>=1.2.0:
+    # this block is to support sklearn>=1.2.0,<1.3.0
+
+    def _fit_context(*, prefer_skip_nested_validation):
+        def decorator(fit_method):
+            def wrapper(estimator, *args, **kwargs):
+                return fit_method(estimator, *args, **kwargs)
+
+            return wrapper
+
+        return decorator
 
 
 PenaltyType = Optional[Literal["l1", "l2", "elasticnet"]]
@@ -505,9 +521,7 @@ class ConstrainedLogisticRegression(LogisticRegression):
             l1_ratio=l1_ratio,
         )
 
-    # TODO: `@_fit_context(prefer_skip_nested_validation=True)` introduced in sklearn
-    #  1.3, but sagemaker supports 1.2.1 - consider not supporting sagemaker default
-    #  image, or add solution to handle both cases
+    @_fit_context(prefer_skip_nested_validation=True)
     def fit(
         self,
         X: np.ndarray,
@@ -633,7 +647,7 @@ class ConstrainedLogisticRegression(LogisticRegression):
 
         return self
 
-    def as_logistic_regression(self) -> LogisticRegression:
+    def to_logistic_regression(self) -> LogisticRegression:
         check_is_fitted(self)
         new = LogisticRegression()
         for k, v in self.__dict__.items():

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -507,6 +507,9 @@ class ConstrainedLogisticRegression(LogisticRegression):
             l1_ratio=l1_ratio,
         )
 
+    # TODO: `@_fit_context(prefer_skip_nested_validation=True)` introduced in sklearn
+    #  1.3, but sagemaker supports 1.2.1 - consider not supporting sagemaker default
+    #  image, or add solution to handle both cases
     def fit(
         self,
         X: np.ndarray,

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -12,6 +12,7 @@ Implementation based on scikit-learn Logistic Regression.
 
 import numbers
 import warnings
+from typing import Any, Literal, Optional, Union
 
 import cvxpy as cp
 import numpy as np
@@ -26,7 +27,17 @@ from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 from sklearn.utils._param_validation import StrOptions, Interval
 
 
-def _check_solver(solver, penalty, bounds, constraints, warm_start, l1_ratio):
+PenaltyType = Optional[Literal["l1", "l2", "elasticnet"]]
+
+
+def _check_solver(
+    solver: Literal["ecos", "scs", "L-BFGS-B"],
+    penalty: PenaltyType,
+    bounds: Optional[Bounds],
+    constraints: Optional[LinearConstraint],
+    warm_start: bool,
+    l1_ratio: Optional[float],
+) -> None:
     if solver == "L-BFGS-B":
         if penalty in ("l1", "elasticnet") and bounds is not None:
             raise ValueError(
@@ -59,7 +70,7 @@ def _check_solver(solver, penalty, bounds, constraints, warm_start, l1_ratio):
         )
 
 
-def _check_bounds(bounds, n, fit_intercept):
+def _check_bounds(bounds: Bounds, n: int, fit_intercept: bool) -> None:
     if not isinstance(bounds, Bounds):
         raise TypeError("bounds is not of type scipy.optimize.Bounds.")
 
@@ -74,7 +85,9 @@ def _check_bounds(bounds, n, fit_intercept):
         )
 
 
-def _check_constraints(constraints, n, fit_intercept):
+def _check_constraints(
+    constraints: LinearConstraint, n: int, fit_intercept: bool
+) -> None:
     if not isinstance(constraints, LinearConstraint):
         raise TypeError(
             "constraints is not of type " "scipy.optimize.LinearConstraint."
@@ -95,12 +108,20 @@ def _check_constraints(constraints, n, fit_intercept):
 
 
 def _logistic_l1_loss_and_grad(
-    w2, X, y, alpha, penalty, fit_intercept, l1_ratio, sample_weight
-):
+    w2: np.ndarray,
+    X: np.ndarray,
+    y: np.ndarray,
+    alpha: float,
+    penalty: PenaltyType,
+    fit_intercept: bool,
+    l1_ratio: Optional[float],
+    sample_weight: Optional[np.ndarray],
+) -> tuple[float, np.ndarray]:
 
     n_samples, n_features = X.shape
 
     grad = np.empty_like(w2)
+    reg = 0.0
     reg_grad = np.zeros(w2.size)
 
     c = 0.0
@@ -146,7 +167,15 @@ def _logistic_l1_loss_and_grad(
     return out, grad
 
 
-def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept, sample_weight):
+def _logistic_loss_and_grad(
+    w: np.ndarray,
+    X: np.ndarray,
+    y: np.ndarray,
+    alpha: float,
+    penalty: PenaltyType,
+    fit_intercept: bool,
+    sample_weight: Optional[np.ndarray],
+) -> tuple[float, np.ndarray]:
 
     n_samples, n_features = X.shape
     grad = np.empty_like(w)
@@ -179,19 +208,19 @@ def _logistic_loss_and_grad(w, X, y, alpha, penalty, fit_intercept, sample_weigh
 
 
 def _fit_lbfgsb(
-    penalty,
-    tol,
-    C,
-    fit_intercept,
-    max_iter,
-    l1_ratio,
-    warm_start_coef,
-    verbose,
-    X,
-    y,
-    sample_weight,
-    bounds=None,
-):
+    penalty: PenaltyType,
+    tol: float,
+    C: float,
+    fit_intercept: bool,
+    max_iter: int,
+    l1_ratio: Optional[float],
+    warm_start_coef: Optional[np.ndarray],
+    verbose: bool,
+    X: np.ndarray,
+    y: np.ndarray,
+    sample_weight: Optional[np.ndarray],
+    bounds: Optional[Bounds] = None,
+) -> tuple[np.ndarray, float]:
 
     m, n = X.shape
 
@@ -215,7 +244,13 @@ def _fit_lbfgsb(
     options = {"disp": verbose, "gtol": tol, "maxiter": max_iter}
 
     res = minimize(
-        func, w0.flatten(), method="L-BFGS-B", jac=True, bounds=bounds, args=args, options=options
+        func,
+        w0.flatten(),
+        method="L-BFGS-B",
+        jac=True,
+        bounds=bounds,
+        args=args,
+        options=options,
     )
 
     if fit_intercept:
@@ -235,21 +270,21 @@ def _fit_lbfgsb(
 
 
 def _fit_cvxpy(
-    solver,
-    penalty,
-    tol,
-    C,
-    fit_intercept,
-    max_iter,
-    l1_ratio,
-    warm_start_coef,
-    verbose,
-    X,
-    y,
-    sample_weight,
-    bounds=None,
-    constraints=None,
-):
+    solver: Literal["ecos", "scs"],
+    penalty: PenaltyType,
+    tol: float,
+    C: float,
+    fit_intercept: bool,
+    max_iter: int,
+    l1_ratio: Optional[float],
+    warm_start_coef: Optional[np.ndarray],
+    verbose: bool,
+    X: np.ndarray,
+    y: np.ndarray,
+    sample_weight: Optional[np.ndarray],
+    bounds: Optional[Bounds] = None,
+    constraints: Optional[LinearConstraint] = None,
+) -> tuple[np.ndarray, float]:
 
     m, n = X.shape
 
@@ -325,9 +360,14 @@ def _fit_cvxpy(
         solve_options = {"solver": cp.ECOS, "abstol": tol}
     elif solver == "scs":
         solve_options = {"solver": cp.SCS, "eps": tol}
+    else:
+        raise ValueError("Unknown solver {}".format(solver))
 
     problem.solve(
-        max_iters=max_iter, verbose=bool(verbose), warm_start=warm_start, **solve_options
+        max_iters=max_iter,
+        verbose=bool(verbose),
+        warm_start=warm_start,
+        **solve_options,
     )
 
     if fit_intercept:
@@ -444,17 +484,17 @@ class ConstrainedLogisticRegression(LogisticRegression):
 
     def __init__(
         self,
-        penalty="l2",
+        penalty: PenaltyType = "l2",
         *,
-        tol=1e-4,
-        C=1.0,
-        fit_intercept=True,
-        class_weight=None,
-        solver="ecos",
-        max_iter=100,
-        verbose=0,
-        warm_start=False,
-        l1_ratio=None,
+        tol: float = 1e-4,
+        C: float = 1.0,
+        fit_intercept: bool = True,
+        class_weight: Optional[Union[dict[Any, float], Literal["balanced"]]] = None,
+        solver: Literal["ecos", "scs", "L-BFGS-B"] = "ecos",
+        max_iter: int = 100,
+        verbose: Union[int, bool] = 0,
+        warm_start: bool = False,
+        l1_ratio: Optional[float] = None,
         **kwargs,
     ):
         super().__init__(
@@ -471,7 +511,14 @@ class ConstrainedLogisticRegression(LogisticRegression):
             **kwargs,
         )
 
-    def fit(self, X, y, sample_weight=None, bounds=None, constraints=None):
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        sample_weight: Optional[np.ndarray] = None,
+        bounds: Optional[Bounds] = None,
+        constraints: Optional[LinearConstraint] = None,
+    ) -> "ConstrainedLogisticRegression":
         """
         Fit the model according to the given training data.
 
@@ -501,7 +548,14 @@ class ConstrainedLogisticRegression(LogisticRegression):
         """
         self._validate_params()
 
-        _check_solver(self.solver, self.penalty, bounds, constraints, self.warm_start, self.l1_ratio)
+        _check_solver(
+            solver=self.solver,
+            penalty=self.penalty,
+            bounds=bounds,
+            constraints=constraints,
+            warm_start=self.warm_start,
+            l1_ratio=self.l1_ratio,
+        )
 
         X, y = self._validate_data(X, y, accept_sparse="csr", order="C")
 
@@ -545,35 +599,35 @@ class ConstrainedLogisticRegression(LogisticRegression):
 
         if self.solver in ("ecos", "scs"):
             coef_, intercept_ = _fit_cvxpy(
-                self.solver,
-                self.penalty,
-                self.tol,
-                self.C,
-                self.fit_intercept,
-                self.max_iter,
-                self.l1_ratio,
-                warm_start_coef,
-                self.verbose,
-                X,
-                y,
-                sample_weight,
-                bounds,
-                constraints,
+                solver=self.solver,
+                penalty=self.penalty,
+                tol=self.tol,
+                C=self.C,
+                fit_intercept=self.fit_intercept,
+                max_iter=self.max_iter,
+                l1_ratio=self.l1_ratio,
+                warm_start_coef=warm_start_coef,
+                verbose=self.verbose,
+                X=X,
+                y=y,
+                sample_weight=sample_weight,
+                bounds=bounds,
+                constraints=constraints,
             )
         else:
             coef_, intercept_ = _fit_lbfgsb(
-                self.penalty,
-                self.tol,
-                self.C,
-                self.fit_intercept,
-                self.max_iter,
-                self.l1_ratio,
-                warm_start_coef,
-                self.verbose,
-                X,
-                y,
-                sample_weight,
-                bounds,
+                penalty=self.penalty,
+                tol=self.tol,
+                C=self.C,
+                fit_intercept=self.fit_intercept,
+                max_iter=self.max_iter,
+                l1_ratio=self.l1_ratio,
+                warm_start_coef=warm_start_coef,
+                verbose=self.verbose,
+                X=X,
+                y=y,
+                sample_weight=sample_weight,
+                bounds=bounds,
             )
 
         self.coef_ = np.asarray([coef_])

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -15,21 +15,15 @@ import warnings
 
 import cvxpy as cp
 import numpy as np
-
 from scipy.optimize import Bounds, LinearConstraint, minimize
 from scipy.special import expit
-
 from sklearn.base import BaseEstimator
-from sklearn.linear_model._base import LinearClassifierMixin
-from sklearn.linear_model._base import SparseCoefMixin
+from sklearn.linear_model._base import LinearClassifierMixin, SparseCoefMixin
 from sklearn.preprocessing import LabelEncoder
-from sklearn.utils import check_consistent_length
-from sklearn.utils import compute_class_weight
+from sklearn.utils import check_consistent_length, compute_class_weight
 from sklearn.utils.extmath import log_logistic, safe_sparse_dot
 from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import check_is_fitted
-from sklearn.utils.validation import check_X_y
-from sklearn.utils.validation import _check_sample_weight
+from sklearn.utils.validation import _check_sample_weight, check_X_y, check_is_fitted
 
 
 def _check_parameters(

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -264,10 +264,7 @@ def _fit_lbfgsb(
 
     m, n = X.shape
 
-    mask = y == 1
-    y_bin = np.ones(y.shape, dtype=X.dtype)
-    y_bin[~mask] = -1.0
-
+    y_bin = np.where(y == 1, 1.0, -1.0).astype(X.dtype)
     if penalty in ("l1", "elasticnet"):
         func = _logistic_l1_loss_and_grad
         w0 = np.zeros(2 * n + int(fit_intercept))

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -412,7 +412,9 @@ def _fit_cvxpy(
     return coef_, intercept_
 
 
-class LogisticRegression(BaseEstimator, LinearClassifierMixin, SparseCoefMixin):
+class ConstrainedLogisticRegression(
+    BaseEstimator, LinearClassifierMixin, SparseCoefMixin
+):
     """
     Constrained Logistic Regression (aka logit, MaxEnt) classifier.
 

--- a/clogistic/clogistic.py
+++ b/clogistic/clogistic.py
@@ -31,30 +31,28 @@ PenaltyType = Optional[Literal["l1", "l2", "elasticnet"]]
 
 
 def _check_solver(
-    solver: Literal["ecos", "scs", "L-BFGS-B"],
+    solver: Literal["ecos", "scs", "lbfgs"],
     penalty: PenaltyType,
     bounds: Optional[Bounds],
     constraints: Optional[LinearConstraint],
     warm_start: bool,
     l1_ratio: Optional[float],
 ) -> None:
-    if solver == "L-BFGS-B":
+    if solver == "lbfgs":
         if penalty in ("l1", "elasticnet") and bounds is not None:
             raise ValueError(
-                'Solver "L-BFGS-B" does not support bound '
+                'Solver "lbfgs" does not support bound '
                 'constraints with penalty "l1" and '
                 '"elasticnet"; choose either "ecos" or "scs" '
                 "solver."
             )
 
         if constraints is not None:
-            raise ValueError(
-                '"L-BFGS-B" solver does not  supports linear ' "constraints."
-            )
+            raise ValueError("'lbfgs' solver does not  supports linear constraints.")
 
         if penalty in ("l1", "elasticnet") and warm_start:
             raise ValueError(
-                'Solver "L-BFGS-B" does not support warm start '
+                'Solver "lbfgs" does not support warm start '
                 'with "l1" and "elasticnet" regularization.'
             )
 
@@ -385,17 +383,17 @@ class ConstrainedLogisticRegression(LogisticRegression):
     Constrained Logistic Regression (aka logit, MaxEnt) classifier.
 
     This class implements regularized logistic regression supported bound
-    and linear constraints using the 'ecos', 'scs' and 'L-BFGS-B' solvers.
+    and linear constraints using the 'ecos', 'scs' and 'lbfgs' solvers.
 
     All solvers support only L1, L2 and Elastic-Net regularization or no
-    regularization. The 'L-BFGS-B' solver supports bound constraints for L2
+    regularization. The 'lbfgs' solver supports bound constraints for L2
     regularization. The 'ecos' and 'scs' solver support bound constraints and
     linear constraints for all regularizations.
 
     Parameters
     ----------
     penalty : {'l1', 'l2', 'elasticnet', 'none'}, default='l2'
-        Used to specify the norm used in the penalization. The 'L-BFGS-B',
+        Used to specify the norm used in the penalization. The 'lbfgs',
         solver supports only 'l2' penalties if bounds are provided.
         If 'none', no regularization is applied.
 
@@ -422,11 +420,11 @@ class ConstrainedLogisticRegression(LogisticRegression):
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
 
-    solver : {'ecos', 'L-BFGS-B', 'scs'}, default='ecos'
+    solver : {'ecos', 'lbfgs', 'scs'}, default='ecos'
         Algorithm/solver to use in the optimization problem.
 
-        - Unconstrained 'L-BFGS-B' handles all regularizations.
-        - Bound constrained 'L-BFGS-B' handles L2 or no penalty.
+        - Unconstrained 'lbfgs' handles all regularizations.
+        - Bound constrained 'lbfgs' handles L2 or no penalty.
         - For other cases, use 'ecos' or 'scs'.
 
         Note that 'ecos' and 'scs' are general-purpose solvers called via
@@ -464,7 +462,7 @@ class ConstrainedLogisticRegression(LogisticRegression):
     References
     ----------
 
-    L-BFGS-B -- Software for Large-scale Bound-constrained Optimization
+    lbfgs -- Software for Large-scale Bound-constrained Optimization
         Ciyou Zhu, Richard Byrd, Jorge Nocedal and Jose Luis Morales.
         http://users.iems.northwestern.edu/~nocedal/L-BFGS-Bb.html
     """
@@ -475,7 +473,7 @@ class ConstrainedLogisticRegression(LogisticRegression):
         "C": [Interval(numbers.Real, 0, None, closed="right")],
         "fit_intercept": ["boolean"],
         "class_weight": [dict, StrOptions({"balanced"}), None],
-        "solver": [StrOptions({"ecos", "L-BFGS-B", "scs"})],
+        "solver": [StrOptions({"ecos", "lbfgs", "scs"})],
         "max_iter": [Interval(numbers.Integral, 0, None, closed="left")],
         "verbose": ["verbose"],
         "warm_start": ["boolean"],
@@ -490,7 +488,7 @@ class ConstrainedLogisticRegression(LogisticRegression):
         C: float = 1.0,
         fit_intercept: bool = True,
         class_weight: Optional[Union[dict[Any, float], Literal["balanced"]]] = None,
-        solver: Literal["ecos", "scs", "L-BFGS-B"] = "ecos",
+        solver: Literal["ecos", "scs", "lbfgs"] = "ecos",
         max_iter: int = 100,
         verbose: Union[int, bool] = 0,
         warm_start: bool = False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-cvxpy>=1.0.31
-numpy>=1.16
-scikit-learn>=0.20.0
-scipy
-pytest
-coverage
+cvxpy==1.4.0
+numpy==1.26.4
+scikit-learn==1.5.0
+scipy==1.12.0
+coverage==7.10.0
+pytest==8.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cvxpy==1.4.0
 numpy==1.26.4
-scikit-learn==1.5.0
+scikit-learn==1.2.0
 scipy==1.12.0
 black==25.1.0
 coverage==7.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ cvxpy==1.4.0
 numpy==1.26.4
 scikit-learn==1.5.0
 scipy==1.12.0
+black==25.1.0
 coverage==7.10.0
 pytest==8.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+# minimal requirements:
 cvxpy==1.4.0
 numpy==1.26.4
 scikit-learn==1.2.0
 scipy==1.12.0
+
+# required for development / testing:
 black==25.1.0
 coverage==7.10.0
+pandas==1.5.3
 pytest==8.4.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
 
 # Read version file
 version_info = {}
-with open("clogistic/_version.py") as f:
+with open("clogistic/__version__.py") as f:
     exec(f.read(), version_info)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ Elastic-Net regularization.
 
 # install requirements
 install_requires = [
-    "cvxpy>=1.0.31",
-    "numpy>=1.16",
-    "scipy",
-    "scikit-learn>=0.20.0",
+    "cvxpy>=1.4.0",
+    "numpy>=1.26.4",
+    "scikit-learn>=1.5.0",
+    "scipy>=1.12.0",
 ]
 
 
@@ -42,7 +42,7 @@ setup(
     platforms="any",
     include_package_data=True,
     license="Apache Licence 2.0",
-    python_requires=">=3.6",
+    python_requires=">=3.10.0",
     install_requires=install_requires,
     tests_require=["pytest"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ Elastic-Net regularization.
 install_requires = [
     "cvxpy>=1.4.0",
     "numpy>=1.26.4",
-    "scikit-learn>=1.5.0",
+    "scikit-learn>=1.2.0",
     "scipy>=1.12.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,18 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-long_description = '''
+long_description = """
 Logistic regression with bound and linear constraints. L1, L2 and
 Elastic-Net regularization.
-'''
+"""
 
 
 # install requirements
 install_requires = [
-    'cvxpy>=1.0.31',
-    'numpy>=1.16',
-    'scipy',
-    'scikit-learn>=0.20.0'
+    "cvxpy>=1.0.31",
+    "numpy>=1.16",
+    "scipy",
+    "scikit-learn>=0.20.0",
 ]
 
 
@@ -31,28 +31,29 @@ with open("clogistic/__version__.py") as f:
 
 
 setup(
-    name='clogistic',
-    version=version_info['__version__'],
+    name="clogistic",
+    version=version_info["__version__"],
     description="Constrained Logistic Regression",
     long_description=long_description,
     author="Guillermo Navas-Palencia",
     author_email="g.navas.palencia@gmail.com",
     url="https://github.com/guillermo-navas-palencia/clogistic",
-    packages=['clogistic'],
+    packages=["clogistic"],
     platforms="any",
     include_package_data=True,
     license="Apache Licence 2.0",
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     install_requires=install_requires,
-    tests_require=['pytest'],
+    tests_require=["pytest"],
     classifiers=[
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3'],
-    keywords='machine-learning, logistic-regression, statistics, data-science'
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords="machine-learning, logistic-regression, statistics, data-science",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 from scipy.special import expit
 from sklearn.datasets import load_breast_cancer
@@ -16,3 +17,11 @@ def fake_data(n: int = 1_000, p: int = 10, seed: int = 42):
 @pytest.fixture(scope="session")
 def breast_cancer_data():
     return load_breast_cancer(return_X_y=True)
+
+
+@pytest.fixture(scope="session")
+def breast_cancer_dataframe(breast_cancer_data):
+    X, y = breast_cancer_data
+    X = pd.DataFrame(X, columns=["feature_{}".format(i) for i in range(X.shape[1])])
+    y = pd.Series(y, name="target")
+    return X, y

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,9 @@ def fake_data(n: int = 1_000, p: int = 10, seed: int = 42):
     X = rng.random((n, p))
     w = rng.uniform(-0.4, 0.4, p)
     y = rng.binomial(1, expit(X @ w))
-    return X, y
+    return X, y, w
 
 
 @pytest.fixture(scope="session")
 def breast_cancer_data():
     return load_breast_cancer(return_X_y=True)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+from scipy.special import expit
+from sklearn.datasets import load_breast_cancer
+
+
+@pytest.fixture(scope="session")
+def fake_data(n: int = 1_000, p: int = 10, seed: int = 42):
+    rng = np.random.default_rng(seed)
+    X = rng.random((n, p))
+    w = rng.uniform(-0.4, 0.4, p)
+    y = rng.binomial(1, expit(X @ w))
+    return X, y
+
+
+@pytest.fixture(scope="session")
+def breast_cancer_data():
+    return load_breast_cancer(return_X_y=True)
+

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -45,9 +45,9 @@ def test_solver():
     X, y = load_breast_cancer(return_X_y=True)
 
     clfs = [
-        ConstrainedLogisticRegression(solver="L-BFGS-B", penalty="l1", warm_start=True),
+        ConstrainedLogisticRegression(solver="lbfgs", penalty="l1", warm_start=True),
         ConstrainedLogisticRegression(
-            solver="L-BFGS-B", penalty="elasticnet", warm_start=True
+            solver="lbfgs", penalty="elasticnet", warm_start=True
         ),
     ]
     for clf in clfs:
@@ -59,8 +59,8 @@ def test_solver():
     bounds = Bounds(lb, ub)
 
     clfs = [
-        ConstrainedLogisticRegression(solver="L-BFGS-B", penalty="l1"),
-        ConstrainedLogisticRegression(solver="L-BFGS-B", penalty="elasticnet"),
+        ConstrainedLogisticRegression(solver="lbfgs", penalty="l1"),
+        ConstrainedLogisticRegression(solver="lbfgs", penalty="elasticnet"),
     ]
 
     for clf in clfs:
@@ -154,7 +154,7 @@ def test_predict_breast_cancer():
 
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data
-    for solver in ("L-BFGS-B", "ecos", "scs"):
+    for solver in ("lbfgs", "ecos", "scs"):
         for penalty in (None, "l1", "l2", "elasticnet"):
             clf = ConstrainedLogisticRegression(
                 solver=solver, penalty=penalty, l1_ratio=0.5
@@ -179,7 +179,7 @@ def test_predict_breast_cancer_no_intercept():
 
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data without intercept
-    for solver in ("L-BFGS-B", "ecos"):
+    for solver in ("lbfgs", "ecos"):
         for penalty in (None, "l1", "l2", "elasticnet"):
             clf = ConstrainedLogisticRegression(
                 solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
@@ -237,7 +237,7 @@ def test_warm_start():
     X, y = load_breast_cancer(return_X_y=True)
 
     clf_l2_lbfgsb = ConstrainedLogisticRegression(
-        solver="L-BFGS-B", penalty="l2", warm_start=True
+        solver="lbfgs", penalty="l2", warm_start=True
     )
     clf_l2_ecos = ConstrainedLogisticRegression(
         solver="ecos", penalty="l2", warm_start=True
@@ -256,7 +256,7 @@ def test_class_weight():
     X, y = load_breast_cancer(return_X_y=True)
 
     clf_l2_lbfgsb = ConstrainedLogisticRegression(
-        solver="L-BFGS-B", penalty="l2", class_weight="balanced"
+        solver="lbfgs", penalty="l2", class_weight="balanced"
     )
     clf_l2_ecos = ConstrainedLogisticRegression(
         solver="ecos", penalty="l2", class_weight={0: 1, 1: 5}
@@ -291,7 +291,7 @@ def test_close_to_unconstrained():
     w = rng.uniform(-0.4, 0.4, X.shape[1])
 
     lr = LogisticRegression()
-    clf = ConstrainedLogisticRegression(solver="L-BFGS-B")
+    clf = ConstrainedLogisticRegression(solver="lbfgs")
     unbounded_intercept = Bounds([0] * (X.shape[1]) + [-np.inf])
 
     y = rng.binomial(1, expit(X @ w))

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -10,6 +10,40 @@ from clogistic import ConstrainedLogisticRegression
 from tests.conftest import fake_data
 
 
+def bounds_and_constraints(
+    p: int,
+    fit_intercept: bool = True,
+) -> tuple[Bounds, LinearConstraint]:
+    if fit_intercept:
+        p = p + 1
+
+    lb = np.r_[np.full(p - 1, -1), -np.inf]
+    ub = np.r_[np.zeros(p - 1), np.inf]
+    bounds = Bounds(lb, ub)
+
+    lb = np.array([0.0])
+    ub = np.array([0.5])
+    A = np.zeros((1, p))
+    constraints = LinearConstraint(A, lb, ub)
+
+    return bounds, constraints
+
+
+def assert_predictions(
+    clf: LogisticRegression, X: np.ndarray, y: np.ndarray, value: float = 0.9
+) -> None:
+    assert np.all(np.unique(y) == clf.classes_)
+
+    pred = clf.predict(X)
+    assert np.mean(pred == y) > value
+
+    probabilities = clf.predict_proba(X)
+    assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
+
+    pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
+    assert np.mean(pred == y) > value
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -40,19 +74,10 @@ def test_parameters(fake_data, kwargs):
 )
 def test_solver(fake_data, clf):
     X, y, _ = fake_data
-
-    lb = np.r_[np.full(X.shape[1], -1), -np.inf]
-    ub = np.r_[np.zeros(X.shape[1]), np.inf]
-    bounds = Bounds(lb, ub)
+    bounds, constraints = bounds_and_constraints(X.shape[1])
 
     with pytest.raises(ValueError):
         clf.fit(X, y, bounds=bounds)
-
-    lb = np.array([0.0])
-    ub = np.array([0.5])
-    A = np.zeros((1, X.shape[1] + 1))
-    A[0, :2] = np.array([-1, 1])
-    constraints = LinearConstraint(A, lb, ub)
 
     with pytest.raises(ValueError):
         clf.fit(X, y, constraints=constraints)
@@ -70,24 +95,23 @@ def test_target(fake_data):
 
 def test_bounds_and_constraints(fake_data):
     X, y, _ = fake_data
-    lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
-    ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
+    bounds, constraints = bounds_and_constraints(X.shape[1], fit_intercept=False)
 
     with pytest.raises(TypeError):
-        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=[(-np.inf, np.inf)] * X.shape[1])
+        ConstrainedLogisticRegression(penalty="l2").fit(
+            X, y, bounds=[(-np.inf, np.inf)] * X.shape[1]
+        )
 
     with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=Bounds(lb, ub))
-
-    lb = np.array([0.0])
-    ub = np.array([0.5])
-    A = np.zeros((1, X.shape[1]))
+        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
     with pytest.raises(TypeError):
-        ConstrainedLogisticRegression().fit(X, y, constraints=[A, lb, ub])
+        ConstrainedLogisticRegression().fit(
+            X, y, constraints=[constraints.A, constraints.lb, constraints.ub]
+        )
 
     with pytest.raises(ValueError):
-        ConstrainedLogisticRegression().fit(X, y, constraints=LinearConstraint(A, lb, ub))
+        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
 
 @pytest.mark.parametrize(
@@ -104,18 +128,8 @@ def test_predict_breast_cancer(breast_cancer_data, solver, penalty, fit_intercep
     # Test constrained logistic regression with the breast cancer dataset
     # Test that all solvers with all regularizations score (>0.93) for the training data
     clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
-
     clf.fit(X, y)
-    assert np.all(np.unique(y) == clf.classes_)
-
-    pred = clf.predict(X)
-    assert np.mean(pred == y) > 0.93
-
-    probabilities = clf.predict_proba(X)
-    assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
-
-    pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-    assert np.mean(pred == y) > 0.9
+    assert_predictions(clf, X, y)
 
 
 @pytest.mark.parametrize(
@@ -128,31 +142,13 @@ def test_predict_breast_cancer(breast_cancer_data, solver, penalty, fit_intercep
 def test_predict_breast_cancer_bounds_constraints(breast_cancer_data, solver, penalty):
     # Test constrained logistic regression with the breast cancer dataset
     X, y = breast_cancer_data
-
-    lb = np.r_[np.full(X.shape[1], -1), -np.inf]
-    ub = np.r_[np.zeros(X.shape[1]), np.inf]
-    bounds = Bounds(lb, ub)
-
-    lb = np.array([0.0])
-    ub = np.array([0.5])
-    A = np.zeros((1, X.shape[1] + 1))
-    A[0, :2] = np.array([-1, 1])
-    constraints = LinearConstraint(A, lb, ub)
+    bounds, constraints = bounds_and_constraints(X.shape[1])
 
     # Test that all solvers with all regularizations score (>0.93) for the training data
     clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
 
     clf.fit(X, y, bounds=bounds, constraints=constraints)
-    assert np.all(np.unique(y) == clf.classes_)
-
-    pred = clf.predict(X)
-    assert np.mean(pred == y) > 0.93
-
-    probabilities = clf.predict_proba(X)
-    assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
-
-    pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-    assert np.mean(pred == y) > 0.9
+    assert_predictions(clf, X, y)
 
 
 @pytest.mark.parametrize("solver", ("ecos", "scs"))

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -1,71 +1,50 @@
 import numpy as np
 import pytest
-
 from scipy.optimize import Bounds, LinearConstraint
 from scipy.special import expit
-from sklearn.datasets import load_breast_cancer
 from sklearn.linear_model import LogisticRegression
 
 from clogistic import ConstrainedLogisticRegression
+from tests.conftest import fake_data
 
 
-def test_parameters():
-    # Test parameters
-    X, y = load_breast_cancer(return_X_y=True)
-
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"penalty": "new_penalty"},
+        {"penalty": "elasticnet"},
+        {"tol": -1e-3},
+        {"fit_intercept": 0},
+        {"class_weight": []},
+        {"class_weight": "unbalanced"},
+        {"solver": "new_solver"},
+        {"max_iter": -10},
+        {"warm_start": 1},
+        {"solver": "lbfgs", "penalty": "l1", "warm_start": True},
+        {"solver": "lbfgs", "penalty": "elasticnet", "warm_start": True},
+    ],
+)
+def test_parameters(fake_data, kwargs):
     with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(penalty="new_penalty").fit(X, y)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(penalty="elasticnet").fit(X, y)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(tol=-1e-3).fit(X, y)
-
-    with pytest.raises(TypeError):
-        ConstrainedLogisticRegression(fit_intercept=0).fit(X, y)
-
-    with pytest.raises(TypeError):
-        ConstrainedLogisticRegression(class_weight=[]).fit(X, y)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(class_weight="unbalanced").fit(X, y)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(solver="new_solver").fit(X, y)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(max_iter=-10).fit(X, y)
-
-    with pytest.raises(TypeError):
-        ConstrainedLogisticRegression(warm_start=1).fit(X, y)
+        ConstrainedLogisticRegression(**kwargs).fit(*fake_data)
 
 
-def test_solver():
-    X, y = load_breast_cancer(return_X_y=True)
-
-    clfs = [
-        ConstrainedLogisticRegression(solver="lbfgs", penalty="l1", warm_start=True),
-        ConstrainedLogisticRegression(
-            solver="lbfgs", penalty="elasticnet", warm_start=True
-        ),
-    ]
-    for clf in clfs:
-        with pytest.raises(ValueError):
-            clf.fit(X, y)
+@pytest.mark.parametrize(
+    "clf",
+    [
+        ConstrainedLogisticRegression(solver="lbfgs", penalty="l1"),
+        ConstrainedLogisticRegression(solver="lbfgs", penalty="elasticnet"),
+    ],
+)
+def test_solver(fake_data, clf):
+    X, y = fake_data
 
     lb = np.r_[np.full(X.shape[1], -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1]), np.inf]
     bounds = Bounds(lb, ub)
 
-    clfs = [
-        ConstrainedLogisticRegression(solver="lbfgs", penalty="l1"),
-        ConstrainedLogisticRegression(solver="lbfgs", penalty="elasticnet"),
-    ]
-
-    for clf in clfs:
-        with pytest.raises(ValueError):
-            clf.fit(X, y, bounds=bounds)
+    with pytest.raises(ValueError):
+        clf.fit(X, y, bounds=bounds)
 
     lb = np.array([0.0])
     ub = np.array([0.5])
@@ -73,84 +52,45 @@ def test_solver():
     A[0, :2] = np.array([-1, 1])
     constraints = LinearConstraint(A, lb, ub)
 
-    for clf in clfs:
-        with pytest.raises(ValueError):
-            clf.fit(X, y, constraints=constraints)
+    with pytest.raises(ValueError):
+        clf.fit(X, y, constraints=constraints)
 
 
-def test_target():
-    X, y = load_breast_cancer(return_X_y=True)
+def test_target(fake_data):
+    X, y = fake_data
 
     with pytest.raises(ValueError):
-        y2 = np.random.randn(y.size)
-        ConstrainedLogisticRegression().fit(X, y2)
+        ConstrainedLogisticRegression().fit(X, np.random.randn(y.size))
 
     with pytest.raises(ValueError):
-        y2 = np.ones(y.size)
-        ConstrainedLogisticRegression().fit(X, y2)
+        ConstrainedLogisticRegression().fit(X, np.ones(y.size))
 
 
-def test_bounds():
-    X, y = load_breast_cancer(return_X_y=True)
-
-    bounds = [(-np.inf, np.inf)] * X.shape[1]
-    with pytest.raises(TypeError):
-        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
-
+def test_bounds_and_constraints(fake_data):
+    X, y = fake_data
     lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
-    bounds = Bounds(lb, ub)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
-
-    lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
-    ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
-    bounds = Bounds(lb, ub)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
-
-
-@pytest.mark.skip(reason="these issues are dalt internally within scipy")
-def test_constraints():
-    X, y = load_breast_cancer(return_X_y=True)
-
-    lb = np.array([0.0])
-    ub = np.array([0.5])
-    A = np.zeros((1, X.shape[1] + 1))
-    A[0, :2] = np.array([-1, 1])
 
     with pytest.raises(TypeError):
-        ConstrainedLogisticRegression().fit(X, y, constraints=[A, lb, ub])
-
-    lb = np.array([0.0])
-    ub = np.array([0.5])
-    constraints = LinearConstraint(A, lb, ub)
+        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=[(-np.inf, np.inf)] * X.shape[1])
 
     with pytest.raises(ValueError):
-        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
+        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=Bounds(lb, ub))
 
     lb = np.array([0.0])
     ub = np.array([0.5])
     A = np.zeros((1, X.shape[1]))
-    constraints = LinearConstraint(A, lb, ub)
+
+    with pytest.raises(TypeError):
+        ConstrainedLogisticRegression().fit(X, y, constraints=[A, lb, ub])
 
     with pytest.raises(ValueError):
-        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
-
-    lb = np.array([0.0, 0.2])
-    ub = np.array([0.5, 0.2])
-    A = np.zeros((1, X.shape[1] + 1))
-    constraints = LinearConstraint(A, lb, ub)
-
-    with pytest.raises(ValueError):
-        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
+        ConstrainedLogisticRegression().fit(X, y, constraints=LinearConstraint(A, lb, ub))
 
 
-def test_predict_breast_cancer():
+def test_predict_breast_cancer(breast_cancer_data):
     # Test constrained logistic regression with the breast cancer dataset
-    X, y = load_breast_cancer(return_X_y=True)
+    X, y = breast_cancer_data
 
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data
@@ -173,9 +113,9 @@ def test_predict_breast_cancer():
             assert np.mean(pred == y) > 0.9
 
 
-def test_predict_breast_cancer_no_intercept():
+def test_predict_breast_cancer_no_intercept(breast_cancer_data):
     # Test constrained logistic regression with the breast cancer dataset
-    X, y = load_breast_cancer(return_X_y=True)
+    X, y = breast_cancer_data
 
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data without intercept
@@ -198,9 +138,9 @@ def test_predict_breast_cancer_no_intercept():
             assert np.mean(pred == y) > 0.9
 
 
-def test_predict_breast_cancer_bounds_constraints():
+def test_predict_breast_cancer_bounds_constraints(breast_cancer_data):
     # Test constrained logistic regression with the breast cancer dataset
-    X, y = load_breast_cancer(return_X_y=True)
+    X, y = breast_cancer_data
 
     lb = np.r_[np.full(X.shape[1], -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1]), np.inf]
@@ -233,8 +173,8 @@ def test_predict_breast_cancer_bounds_constraints():
             assert np.mean(pred == y) > 0.9
 
 
-def test_warm_start():
-    X, y = load_breast_cancer(return_X_y=True)
+def test_warm_start(breast_cancer_data):
+    X, y = breast_cancer_data
 
     clf_l2_lbfgsb = ConstrainedLogisticRegression(
         solver="lbfgs", penalty="l2", warm_start=True
@@ -252,8 +192,8 @@ def test_warm_start():
         assert score1 == pytest.approx(score2, rel=1e-1)
 
 
-def test_class_weight():
-    X, y = load_breast_cancer(return_X_y=True)
+def test_class_weight(breast_cancer_data):
+    X, y = breast_cancer_data
 
     clf_l2_lbfgsb = ConstrainedLogisticRegression(
         solver="lbfgs", penalty="l2", class_weight="balanced"
@@ -268,8 +208,8 @@ def test_class_weight():
         assert np.mean(pred == y) > 0.93
 
 
-def test_as_logistic_regression():
-    X, y = load_breast_cancer(return_X_y=True)
+def test_as_logistic_regression(breast_cancer_data):
+    X, y = breast_cancer_data
 
     clf = ConstrainedLogisticRegression()
     clf.fit(X, y)

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -1,3 +1,5 @@
+import itertools
+
 import numpy as np
 import pytest
 from scipy.optimize import Bounds, LinearConstraint
@@ -88,57 +90,42 @@ def test_bounds_and_constraints(fake_data):
         ConstrainedLogisticRegression().fit(X, y, constraints=LinearConstraint(A, lb, ub))
 
 
-def test_predict_breast_cancer(breast_cancer_data):
-    # Test constrained logistic regression with the breast cancer dataset
+@pytest.mark.parametrize(
+    "solver, penalty, fit_intercept",
+    itertools.product(
+        ("lbfgs", "ecos", "scs"),
+        (None, "l1", "l2", "elasticnet"),
+        (True, False),
+    ),
+)
+def test_predict_breast_cancer(breast_cancer_data, solver, penalty, fit_intercept):
     X, y = breast_cancer_data
 
-    # Test that all solvers with all regularizations score (>0.93) for the
-    # training data
-    for solver in ("lbfgs", "ecos", "scs"):
-        for penalty in (None, "l1", "l2", "elasticnet"):
-            clf = ConstrainedLogisticRegression(
-                solver=solver, penalty=penalty, l1_ratio=0.5
-            )
-
-            clf.fit(X, y)
-            assert np.all(np.unique(y) == clf.classes_)
-
-            pred = clf.predict(X)
-            assert np.mean(pred == y) > 0.93
-
-            probabilities = clf.predict_proba(X)
-            assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
-
-            pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-            assert np.mean(pred == y) > 0.9
-
-
-def test_predict_breast_cancer_no_intercept(breast_cancer_data):
     # Test constrained logistic regression with the breast cancer dataset
-    X, y = breast_cancer_data
+    # Test that all solvers with all regularizations score (>0.93) for the training data
+    clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
 
-    # Test that all solvers with all regularizations score (>0.93) for the
-    # training data without intercept
-    for solver in ("lbfgs", "ecos"):
-        for penalty in (None, "l1", "l2", "elasticnet"):
-            clf = ConstrainedLogisticRegression(
-                solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
-            )
+    clf.fit(X, y)
+    assert np.all(np.unique(y) == clf.classes_)
 
-            clf.fit(X, y)
-            assert np.all(np.unique(y) == clf.classes_)
+    pred = clf.predict(X)
+    assert np.mean(pred == y) > 0.93
 
-            pred = clf.predict(X)
-            assert np.mean(pred == y) > 0.93
+    probabilities = clf.predict_proba(X)
+    assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
 
-            probabilities = clf.predict_proba(X)
-            assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
-
-            pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-            assert np.mean(pred == y) > 0.9
+    pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
+    assert np.mean(pred == y) > 0.9
 
 
-def test_predict_breast_cancer_bounds_constraints(breast_cancer_data):
+@pytest.mark.parametrize(
+    "solver, penalty",
+    itertools.product(
+        ("ecos", "scs"),
+        (None, "l1", "l2", "elasticnet"),
+    ),
+)
+def test_predict_breast_cancer_bounds_constraints(breast_cancer_data, solver, penalty):
     # Test constrained logistic regression with the breast cancer dataset
     X, y = breast_cancer_data
 
@@ -152,44 +139,30 @@ def test_predict_breast_cancer_bounds_constraints(breast_cancer_data):
     A[0, :2] = np.array([-1, 1])
     constraints = LinearConstraint(A, lb, ub)
 
-    # Test that all solvers with all regularizations score (>0.93) for the
-    # training data
-    for solver in ("ecos", "scs"):
-        for penalty in (None, "l1", "l2", "elasticnet"):
-            clf = ConstrainedLogisticRegression(
-                solver=solver, penalty=penalty, l1_ratio=0.5
-            )
+    # Test that all solvers with all regularizations score (>0.93) for the training data
+    clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
 
-            clf.fit(X, y, bounds=bounds, constraints=constraints)
-            assert np.all(np.unique(y) == clf.classes_)
+    clf.fit(X, y, bounds=bounds, constraints=constraints)
+    assert np.all(np.unique(y) == clf.classes_)
 
-            pred = clf.predict(X)
-            assert np.mean(pred == y) > 0.93
+    pred = clf.predict(X)
+    assert np.mean(pred == y) > 0.93
 
-            probabilities = clf.predict_proba(X)
-            assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
+    probabilities = clf.predict_proba(X)
+    assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
 
-            pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-            assert np.mean(pred == y) > 0.9
+    pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
+    assert np.mean(pred == y) > 0.9
 
 
-def test_warm_start(breast_cancer_data):
+@pytest.mark.parametrize("solver", ("ecos", "scs"))
+def test_warm_start(breast_cancer_data, solver):
     X, y = breast_cancer_data
+    clf = ConstrainedLogisticRegression(solver=solver, penalty="l2", warm_start=True)
 
-    clf_l2_lbfgsb = ConstrainedLogisticRegression(
-        solver="lbfgs", penalty="l2", warm_start=True
-    )
-    clf_l2_ecos = ConstrainedLogisticRegression(
-        solver="ecos", penalty="l2", warm_start=True
-    )
-
-    for clf in (clf_l2_lbfgsb, clf_l2_ecos):
-        clf.fit(X, y)
-        score1 = clf.score(X, y)
-        clf.fit(X, y)
-        score2 = clf.score(X, y)
-
-        assert score1 == pytest.approx(score2, rel=1e-1)
+    score1 = clf.fit(X, y).score(X, y)
+    score2 = clf.fit(X, y).score(X, y)
+    assert score1 == pytest.approx(score2, rel=1e-1)
 
 
 def test_class_weight(breast_cancer_data):

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from pytest import approx, raises
 
-from clogistic import LogisticRegression
+from clogistic import ConstrainedLogisticRegression
 
 from scipy.optimize import Bounds
 from scipy.optimize import LinearConstraint
@@ -14,42 +14,44 @@ def test_parameters():
     X, y = load_breast_cancer(return_X_y=True)
 
     with raises(ValueError):
-        LogisticRegression(penalty="new_penalty").fit(X, y)
+        ConstrainedLogisticRegression(penalty="new_penalty").fit(X, y)
 
     with raises(ValueError):
-        LogisticRegression(penalty="elasticnet").fit(X, y)
+        ConstrainedLogisticRegression(penalty="elasticnet").fit(X, y)
 
     with raises(ValueError):
-        LogisticRegression(tol=-1e-3).fit(X, y)
+        ConstrainedLogisticRegression(tol=-1e-3).fit(X, y)
 
     with raises(TypeError):
-        LogisticRegression(fit_intercept=0).fit(X, y)
+        ConstrainedLogisticRegression(fit_intercept=0).fit(X, y)
 
     with raises(TypeError):
-        LogisticRegression(class_weight=[]).fit(X, y)
+        ConstrainedLogisticRegression(class_weight=[]).fit(X, y)
 
     with raises(ValueError):
-        LogisticRegression(class_weight="unbalanced").fit(X, y)
+        ConstrainedLogisticRegression(class_weight="unbalanced").fit(X, y)
 
     with raises(ValueError):
-        LogisticRegression(solver="new_solver").fit(X, y)
+        ConstrainedLogisticRegression(solver="new_solver").fit(X, y)
 
     with raises(ValueError):
-        LogisticRegression(max_iter=-10).fit(X, y)
+        ConstrainedLogisticRegression(max_iter=-10).fit(X, y)
 
     with raises(TypeError):
-        LogisticRegression(warm_start=1).fit(X, y)
+        ConstrainedLogisticRegression(warm_start=1).fit(X, y)
 
     with raises(TypeError):
-        LogisticRegression(verbose=1).fit(X, y)
+        ConstrainedLogisticRegression(verbose=1).fit(X, y)
 
 
 def test_solver():
     X, y = load_breast_cancer(return_X_y=True)
 
     clfs = [
-        LogisticRegression(solver="L-BFGS-B", penalty="l1", warm_start=True),
-        LogisticRegression(solver="L-BFGS-B", penalty="elasticnet", warm_start=True),
+        ConstrainedLogisticRegression(solver="L-BFGS-B", penalty="l1", warm_start=True),
+        ConstrainedLogisticRegression(
+            solver="L-BFGS-B", penalty="elasticnet", warm_start=True
+        ),
     ]
     for clf in clfs:
         with raises(ValueError):
@@ -60,8 +62,8 @@ def test_solver():
     bounds = Bounds(lb, ub)
 
     clfs = [
-        LogisticRegression(solver="L-BFGS-B", penalty="l1"),
-        LogisticRegression(solver="L-BFGS-B", penalty="elasticnet"),
+        ConstrainedLogisticRegression(solver="L-BFGS-B", penalty="l1"),
+        ConstrainedLogisticRegression(solver="L-BFGS-B", penalty="elasticnet"),
     ]
 
     for clf in clfs:
@@ -84,11 +86,11 @@ def test_target():
 
     with raises(ValueError):
         y2 = np.random.randn(y.size)
-        LogisticRegression().fit(X, y2)
+        ConstrainedLogisticRegression().fit(X, y2)
 
     with raises(ValueError):
         y2 = np.ones(y.size)
-        LogisticRegression().fit(X, y2)
+        ConstrainedLogisticRegression().fit(X, y2)
 
 
 def test_bounds():
@@ -96,21 +98,21 @@ def test_bounds():
 
     bounds = [(-np.inf, np.inf)] * X.shape[1]
     with raises(TypeError):
-        LogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
+        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
     lb = np.r_[np.full(X.shape[1], -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
     with raises(ValueError):
-        LogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
+        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
     lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
     with raises(ValueError):
-        LogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
+        ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
 
 def test_contraints():
@@ -122,14 +124,14 @@ def test_contraints():
     A[0, :2] = np.array([-1, 1])
 
     with raises(TypeError):
-        LogisticRegression().fit(X, y, constraints=[A, lb, ub])
+        ConstrainedLogisticRegression().fit(X, y, constraints=[A, lb, ub])
 
     lb = np.array([0.0])
     ub = np.array([0.5, 0.2])
     constraints = LinearConstraint(A, lb, ub)
 
     with raises(ValueError):
-        LogisticRegression().fit(X, y, constraints=constraints)
+        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
     lb = np.array([0.0])
     ub = np.array([0.5])
@@ -137,7 +139,7 @@ def test_contraints():
     constraints = LinearConstraint(A, lb, ub)
 
     with raises(ValueError):
-        LogisticRegression().fit(X, y, constraints=constraints)
+        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
     lb = np.array([0.0, 0.2])
     ub = np.array([0.5, 0.2])
@@ -145,7 +147,7 @@ def test_contraints():
     constraints = LinearConstraint(A, lb, ub)
 
     with raises(ValueError):
-        LogisticRegression().fit(X, y, constraints=constraints)
+        ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
 
 def test_predict_breast_cancer():
@@ -157,9 +159,11 @@ def test_predict_breast_cancer():
     for solver in ("L-BFGS-B", "ecos", "scs"):
         for penalty in ("none", "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
-                clf = LogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
+                clf = ConstrainedLogisticRegression(
+                    solver=solver, penalty=penalty, l1_ratio=0.5
+                )
             else:
-                clf = LogisticRegression(solver=solver, penalty=penalty)
+                clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty)
 
             clf.fit(X, y)
             assert np.all(np.unique(y) == clf.classes_)
@@ -183,11 +187,11 @@ def test_predict_breast_cancer_no_intercept():
     for solver in ("L-BFGS-B", "ecos"):
         for penalty in ("none", "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
-                clf = LogisticRegression(
+                clf = ConstrainedLogisticRegression(
                     solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
                 )
             else:
-                clf = LogisticRegression(
+                clf = ConstrainedLogisticRegression(
                     solver=solver, penalty=penalty, fit_intercept=False
                 )
 
@@ -223,9 +227,11 @@ def test_predict_breast_cancer_bounds_constraints():
     for solver in ("ecos", "scs"):
         for penalty in ("none", "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
-                clf = LogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
+                clf = ConstrainedLogisticRegression(
+                    solver=solver, penalty=penalty, l1_ratio=0.5
+                )
             else:
-                clf = LogisticRegression(solver=solver, penalty=penalty)
+                clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty)
 
             clf.fit(X, y, bounds=bounds, constraints=constraints)
             assert np.all(np.unique(y) == clf.classes_)
@@ -243,8 +249,12 @@ def test_predict_breast_cancer_bounds_constraints():
 def test_warm_start():
     X, y = load_breast_cancer(return_X_y=True)
 
-    clf_l2_lbfgsb = LogisticRegression(solver="L-BFGS-B", penalty="l2", warm_start=True)
-    clf_l2_ecos = LogisticRegression(solver="ecos", penalty="l2", warm_start=True)
+    clf_l2_lbfgsb = ConstrainedLogisticRegression(
+        solver="L-BFGS-B", penalty="l2", warm_start=True
+    )
+    clf_l2_ecos = ConstrainedLogisticRegression(
+        solver="ecos", penalty="l2", warm_start=True
+    )
 
     for clf in (clf_l2_lbfgsb, clf_l2_ecos):
         clf.fit(X, y)
@@ -258,10 +268,10 @@ def test_warm_start():
 def test_class_weight():
     X, y = load_breast_cancer(return_X_y=True)
 
-    clf_l2_lbfgsb = LogisticRegression(
+    clf_l2_lbfgsb = ConstrainedLogisticRegression(
         solver="L-BFGS-B", penalty="l2", class_weight="balanced"
     )
-    clf_l2_ecos = LogisticRegression(
+    clf_l2_ecos = ConstrainedLogisticRegression(
         solver="ecos", penalty="l2", class_weight={0: 1, 1: 5}
     )
 

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -39,7 +39,7 @@ def test_parameters(fake_data, kwargs):
     ],
 )
 def test_solver(fake_data, clf):
-    X, y = fake_data
+    X, y, _ = fake_data
 
     lb = np.r_[np.full(X.shape[1], -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1]), np.inf]
@@ -59,7 +59,7 @@ def test_solver(fake_data, clf):
 
 
 def test_target(fake_data):
-    X, y = fake_data
+    X, y, _ = fake_data
 
     with pytest.raises(ValueError):
         ConstrainedLogisticRegression().fit(X, np.random.randn(y.size))
@@ -69,7 +69,7 @@ def test_target(fake_data):
 
 
 def test_bounds_and_constraints(fake_data):
-    X, y = fake_data
+    X, y, _ = fake_data
     lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
 
@@ -165,24 +165,24 @@ def test_warm_start(breast_cancer_data, solver):
     assert score1 == pytest.approx(score2, rel=1e-1)
 
 
-def test_class_weight(breast_cancer_data):
+@pytest.mark.parametrize(
+    "solver, class_weight",
+    [
+        ("lbfgs", "balanced"),
+        ("ecos", {0: 1, 1: 5}),
+    ],
+)
+def test_class_weight(breast_cancer_data, solver, class_weight):
     X, y = breast_cancer_data
-
-    clf_l2_lbfgsb = ConstrainedLogisticRegression(
-        solver="lbfgs", penalty="l2", class_weight="balanced"
+    clf = ConstrainedLogisticRegression(
+        solver=solver, penalty="l2", class_weight=class_weight
     )
-    clf_l2_ecos = ConstrainedLogisticRegression(
-        solver="ecos", penalty="l2", class_weight={0: 1, 1: 5}
-    )
-
-    for clf in (clf_l2_lbfgsb, clf_l2_ecos):
-        clf.fit(X, y)
-        pred = clf.predict(X)
-        assert np.mean(pred == y) > 0.93
+    pred = clf.fit(X, y).predict(X)
+    assert np.mean(pred == y) > 0.93
 
 
-def test_as_logistic_regression(breast_cancer_data):
-    X, y = breast_cancer_data
+def test_as_logistic_regression(fake_data):
+    X, y, _ = fake_data
 
     clf = ConstrainedLogisticRegression()
     clf.fit(X, y)
@@ -198,21 +198,19 @@ def test_as_logistic_regression(breast_cancer_data):
         lr.fit(X, y)  # solver is "ecos"
 
 
-def test_close_to_unconstrained():
+def test_close_to_unconstrained(fake_data):
     rng = np.random.default_rng(42)
-    X = rng.random((1_000, 10))
-    w = rng.uniform(-0.4, 0.4, X.shape[1])
+    X, y, w = fake_data
+    y_pos = rng.binomial(1, expit(X @ np.abs(w)))
 
     lr = LogisticRegression()
     clf = ConstrainedLogisticRegression(solver="lbfgs")
     unbounded_intercept = Bounds([0] * (X.shape[1]) + [-np.inf])
 
-    y = rng.binomial(1, expit(X @ w))
     lr.fit(X, y)
     clf.fit(X, y, bounds=unbounded_intercept)
     assert not np.array_equal(clf.coef_, lr.coef_)
 
-    y_pos = rng.binomial(1, expit(X @ np.abs(w)))
     lr.fit(X, y_pos)
     clf.fit(X, y_pos, bounds=unbounded_intercept)
     np.testing.assert_allclose(clf.coef_, lr.coef_, atol=1e-2)

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -100,7 +100,7 @@ def test_bounds():
     with raises(TypeError):
         ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
-    lb = np.r_[np.full(X.shape[1], -1), -np.inf]
+    lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
@@ -127,7 +127,7 @@ def test_contraints():
         ConstrainedLogisticRegression().fit(X, y, constraints=[A, lb, ub])
 
     lb = np.array([0.0])
-    ub = np.array([0.5, 0.2])
+    ub = np.array([0.5])
     constraints = LinearConstraint(A, lb, ub)
 
     with raises(ValueError):
@@ -157,7 +157,7 @@ def test_predict_breast_cancer():
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data
     for solver in ("L-BFGS-B", "ecos", "scs"):
-        for penalty in ("none", "l1", "l2", "elasticnet"):
+        for penalty in (None, "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
                 clf = ConstrainedLogisticRegression(
                     solver=solver, penalty=penalty, l1_ratio=0.5
@@ -185,7 +185,7 @@ def test_predict_breast_cancer_no_intercept():
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data without intercept
     for solver in ("L-BFGS-B", "ecos"):
-        for penalty in ("none", "l1", "l2", "elasticnet"):
+        for penalty in (None, "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
                 clf = ConstrainedLogisticRegression(
                     solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
@@ -225,7 +225,7 @@ def test_predict_breast_cancer_bounds_constraints():
     # Test that all solvers with all regularizations score (>0.93) for the
     # training data
     for solver in ("ecos", "scs"):
-        for penalty in ("none", "l1", "l2", "elasticnet"):
+        for penalty in (None, "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
                 clf = ConstrainedLogisticRegression(
                     solver=solver, penalty=penalty, l1_ratio=0.5

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -182,7 +182,7 @@ def test_as_logistic_regression(fake_data):
 
     clf = ConstrainedLogisticRegression()
     clf.fit(X, y)
-    lr = clf.as_logistic_regression()
+    lr = clf.to_logistic_regression()
 
     assert isinstance(lr, LogisticRegression)
     np.testing.assert_allclose(clf.coef_, lr.coef_)

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -115,21 +115,30 @@ def test_bounds_and_constraints(fake_data):
 
 
 @pytest.mark.parametrize(
-    "solver, penalty, fit_intercept",
+    "solver, penalty, fit_intercept, dataframe",
     itertools.product(
         ("lbfgs", "ecos", "scs"),
         (None, "l1", "l2", "elasticnet"),
         (True, False),
+        (True, False),
     ),
 )
-def test_predict_breast_cancer(breast_cancer_data, solver, penalty, fit_intercept):
-    X, y = breast_cancer_data
+def test_predict_breast_cancer(
+    breast_cancer_data,
+    breast_cancer_dataframe,
+    solver,
+    penalty,
+    fit_intercept,
+    dataframe,
+):
+    X, y = breast_cancer_dataframe if dataframe else breast_cancer_data
 
     # Test constrained logistic regression with the breast cancer dataset
     # Test that all solvers with all regularizations score (>0.93) for the training data
     clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
     clf.fit(X, y)
     assert_predictions(clf, X, y)
+    assert hasattr(clf, "feature_names_in_") is dataframe
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -47,10 +47,10 @@ def test_parameters():
 def test_solver():
     X, y = load_breast_cancer(return_X_y=True)
 
-    clfs = [LogisticRegression(solver="L-BFGS-B", penalty="l1",
-                               warm_start=True),
-            LogisticRegression(solver="L-BFGS-B", penalty="elasticnet",
-                               warm_start=True)]
+    clfs = [
+        LogisticRegression(solver="L-BFGS-B", penalty="l1", warm_start=True),
+        LogisticRegression(solver="L-BFGS-B", penalty="elasticnet", warm_start=True),
+    ]
     for clf in clfs:
         with raises(ValueError):
             clf.fit(X, y)
@@ -59,8 +59,10 @@ def test_solver():
     ub = np.r_[np.zeros(X.shape[1]), np.inf]
     bounds = Bounds(lb, ub)
 
-    clfs = [LogisticRegression(solver="L-BFGS-B", penalty="l1"),
-            LogisticRegression(solver="L-BFGS-B", penalty="elasticnet")]
+    clfs = [
+        LogisticRegression(solver="L-BFGS-B", penalty="l1"),
+        LogisticRegression(solver="L-BFGS-B", penalty="elasticnet"),
+    ]
 
     for clf in clfs:
         with raises(ValueError):
@@ -97,14 +99,14 @@ def test_bounds():
         LogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
     lb = np.r_[np.full(X.shape[1], -1), -np.inf]
-    ub = np.r_[np.zeros(X.shape[1]-1), np.inf]
+    ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
     with raises(ValueError):
         LogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
-    lb = np.r_[np.full(X.shape[1]-1, -1), -np.inf]
-    ub = np.r_[np.zeros(X.shape[1]-1), np.inf]
+    lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
+    ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
     with raises(ValueError):
@@ -155,8 +157,7 @@ def test_predict_breast_cancer():
     for solver in ("L-BFGS-B", "ecos", "scs"):
         for penalty in ("none", "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
-                clf = LogisticRegression(solver=solver, penalty=penalty,
-                                         l1_ratio=0.5)
+                clf = LogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
             else:
                 clf = LogisticRegression(solver=solver, penalty=penalty)
 
@@ -170,7 +171,7 @@ def test_predict_breast_cancer():
             assert probabilities.sum(axis=1) == approx(np.ones(X.shape[0]))
 
             pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-            assert np.mean(pred == y) > .9
+            assert np.mean(pred == y) > 0.9
 
 
 def test_predict_breast_cancer_no_intercept():
@@ -182,11 +183,13 @@ def test_predict_breast_cancer_no_intercept():
     for solver in ("L-BFGS-B", "ecos"):
         for penalty in ("none", "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
-                clf = LogisticRegression(solver=solver, penalty=penalty,
-                                         l1_ratio=0.5, fit_intercept=False)
+                clf = LogisticRegression(
+                    solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
+                )
             else:
-                clf = LogisticRegression(solver=solver, penalty=penalty,
-                                         fit_intercept=False)
+                clf = LogisticRegression(
+                    solver=solver, penalty=penalty, fit_intercept=False
+                )
 
             clf.fit(X, y)
             assert np.all(np.unique(y) == clf.classes_)
@@ -198,7 +201,7 @@ def test_predict_breast_cancer_no_intercept():
             assert probabilities.sum(axis=1) == approx(np.ones(X.shape[0]))
 
             pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-            assert np.mean(pred == y) > .9
+            assert np.mean(pred == y) > 0.9
 
 
 def test_predict_breast_cancer_bounds_constraints():
@@ -220,8 +223,7 @@ def test_predict_breast_cancer_bounds_constraints():
     for solver in ("ecos", "scs"):
         for penalty in ("none", "l1", "l2", "elasticnet"):
             if penalty == "elasticnet":
-                clf = LogisticRegression(solver=solver, penalty=penalty,
-                                         l1_ratio=0.5)
+                clf = LogisticRegression(solver=solver, penalty=penalty, l1_ratio=0.5)
             else:
                 clf = LogisticRegression(solver=solver, penalty=penalty)
 
@@ -235,16 +237,14 @@ def test_predict_breast_cancer_bounds_constraints():
             assert probabilities.sum(axis=1) == approx(np.ones(X.shape[0]))
 
             pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
-            assert np.mean(pred == y) > .9
+            assert np.mean(pred == y) > 0.9
 
 
 def test_warm_start():
     X, y = load_breast_cancer(return_X_y=True)
 
-    clf_l2_lbfgsb = LogisticRegression(solver="L-BFGS-B", penalty="l2",
-                                       warm_start=True)
-    clf_l2_ecos = LogisticRegression(solver="ecos", penalty="l2",
-                                     warm_start=True)
+    clf_l2_lbfgsb = LogisticRegression(solver="L-BFGS-B", penalty="l2", warm_start=True)
+    clf_l2_ecos = LogisticRegression(solver="ecos", penalty="l2", warm_start=True)
 
     for clf in (clf_l2_lbfgsb, clf_l2_ecos):
         clf.fit(X, y)
@@ -258,10 +258,12 @@ def test_warm_start():
 def test_class_weight():
     X, y = load_breast_cancer(return_X_y=True)
 
-    clf_l2_lbfgsb = LogisticRegression(solver="L-BFGS-B", penalty="l2",
-                                       class_weight="balanced")
-    clf_l2_ecos = LogisticRegression(solver="ecos", penalty="l2",
-                                     class_weight={0: 1, 1: 5})
+    clf_l2_lbfgsb = LogisticRegression(
+        solver="L-BFGS-B", penalty="l2", class_weight="balanced"
+    )
+    clf_l2_ecos = LogisticRegression(
+        solver="ecos", penalty="l2", class_weight={0: 1, 1: 5}
+    )
 
     for clf in (clf_l2_lbfgsb, clf_l2_ecos):
         clf.fit(X, y)

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 
 from scipy.optimize import Bounds, LinearConstraint
+from scipy.special import expit
 from sklearn.datasets import load_breast_cancer
+from sklearn.linear_model import LogisticRegression
 
 from clogistic import ConstrainedLogisticRegression
 
@@ -154,12 +156,9 @@ def test_predict_breast_cancer():
     # training data
     for solver in ("L-BFGS-B", "ecos", "scs"):
         for penalty in (None, "l1", "l2", "elasticnet"):
-            if penalty == "elasticnet":
-                clf = ConstrainedLogisticRegression(
-                    solver=solver, penalty=penalty, l1_ratio=0.5
-                )
-            else:
-                clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty)
+            clf = ConstrainedLogisticRegression(
+                solver=solver, penalty=penalty, l1_ratio=0.5
+            )
 
             clf.fit(X, y)
             assert np.all(np.unique(y) == clf.classes_)
@@ -182,14 +181,9 @@ def test_predict_breast_cancer_no_intercept():
     # training data without intercept
     for solver in ("L-BFGS-B", "ecos"):
         for penalty in (None, "l1", "l2", "elasticnet"):
-            if penalty == "elasticnet":
-                clf = ConstrainedLogisticRegression(
-                    solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
-                )
-            else:
-                clf = ConstrainedLogisticRegression(
-                    solver=solver, penalty=penalty, fit_intercept=False
-                )
+            clf = ConstrainedLogisticRegression(
+                solver=solver, penalty=penalty, l1_ratio=0.5, fit_intercept=False
+            )
 
             clf.fit(X, y)
             assert np.all(np.unique(y) == clf.classes_)
@@ -222,12 +216,9 @@ def test_predict_breast_cancer_bounds_constraints():
     # training data
     for solver in ("ecos", "scs"):
         for penalty in (None, "l1", "l2", "elasticnet"):
-            if penalty == "elasticnet":
-                clf = ConstrainedLogisticRegression(
-                    solver=solver, penalty=penalty, l1_ratio=0.5
-                )
-            else:
-                clf = ConstrainedLogisticRegression(solver=solver, penalty=penalty)
+            clf = ConstrainedLogisticRegression(
+                solver=solver, penalty=penalty, l1_ratio=0.5
+            )
 
             clf.fit(X, y, bounds=bounds, constraints=constraints)
             assert np.all(np.unique(y) == clf.classes_)
@@ -275,3 +266,40 @@ def test_class_weight():
         clf.fit(X, y)
         pred = clf.predict(X)
         assert np.mean(pred == y) > 0.93
+
+
+def test_as_logistic_regression():
+    X, y = load_breast_cancer(return_X_y=True)
+
+    clf = ConstrainedLogisticRegression()
+    clf.fit(X, y)
+    lr = clf.as_logistic_regression()
+
+    assert isinstance(lr, LogisticRegression)
+    np.testing.assert_allclose(clf.coef_, lr.coef_)
+    np.testing.assert_allclose(clf.intercept_, lr.intercept_)
+    np.testing.assert_allclose(clf.predict_proba(X), lr.predict_proba(X))
+    np.testing.assert_allclose(clf.predict(X), lr.predict(X))
+
+    with pytest.raises(ValueError):
+        lr.fit(X, y)  # solver is "ecos"
+
+
+def test_close_to_unconstrained():
+    rng = np.random.default_rng(42)
+    X = rng.random((1_000, 10))
+    w = rng.uniform(-0.4, 0.4, X.shape[1])
+
+    lr = LogisticRegression()
+    clf = ConstrainedLogisticRegression(solver="L-BFGS-B")
+    unbounded_intercept = Bounds([0] * (X.shape[1]) + [-np.inf])
+
+    y = rng.binomial(1, expit(X @ w))
+    lr.fit(X, y)
+    clf.fit(X, y, bounds=unbounded_intercept)
+    assert not np.array_equal(clf.coef_, lr.coef_)
+
+    y_pos = rng.binomial(1, expit(X @ np.abs(w)))
+    lr.fit(X, y_pos)
+    clf.fit(X, y_pos, bounds=unbounded_intercept)
+    np.testing.assert_allclose(clf.coef_, lr.coef_, atol=1e-2)

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -1,47 +1,42 @@
 import numpy as np
+import pytest
 
-from pytest import approx, raises
+from scipy.optimize import Bounds, LinearConstraint
+from sklearn.datasets import load_breast_cancer
 
 from clogistic import ConstrainedLogisticRegression
-
-from scipy.optimize import Bounds
-from scipy.optimize import LinearConstraint
-from sklearn.datasets import load_breast_cancer
 
 
 def test_parameters():
     # Test parameters
     X, y = load_breast_cancer(return_X_y=True)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(penalty="new_penalty").fit(X, y)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(penalty="elasticnet").fit(X, y)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(tol=-1e-3).fit(X, y)
 
-    with raises(TypeError):
+    with pytest.raises(TypeError):
         ConstrainedLogisticRegression(fit_intercept=0).fit(X, y)
 
-    with raises(TypeError):
+    with pytest.raises(TypeError):
         ConstrainedLogisticRegression(class_weight=[]).fit(X, y)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(class_weight="unbalanced").fit(X, y)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(solver="new_solver").fit(X, y)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(max_iter=-10).fit(X, y)
 
-    with raises(TypeError):
+    with pytest.raises(TypeError):
         ConstrainedLogisticRegression(warm_start=1).fit(X, y)
-
-    with raises(TypeError):
-        ConstrainedLogisticRegression(verbose=1).fit(X, y)
 
 
 def test_solver():
@@ -54,7 +49,7 @@ def test_solver():
         ),
     ]
     for clf in clfs:
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             clf.fit(X, y)
 
     lb = np.r_[np.full(X.shape[1], -1), -np.inf]
@@ -67,7 +62,7 @@ def test_solver():
     ]
 
     for clf in clfs:
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             clf.fit(X, y, bounds=bounds)
 
     lb = np.array([0.0])
@@ -77,18 +72,18 @@ def test_solver():
     constraints = LinearConstraint(A, lb, ub)
 
     for clf in clfs:
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             clf.fit(X, y, constraints=constraints)
 
 
 def test_target():
     X, y = load_breast_cancer(return_X_y=True)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         y2 = np.random.randn(y.size)
         ConstrainedLogisticRegression().fit(X, y2)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         y2 = np.ones(y.size)
         ConstrainedLogisticRegression().fit(X, y2)
 
@@ -97,25 +92,26 @@ def test_bounds():
     X, y = load_breast_cancer(return_X_y=True)
 
     bounds = [(-np.inf, np.inf)] * X.shape[1]
-    with raises(TypeError):
+    with pytest.raises(TypeError):
         ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
     lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
     lb = np.r_[np.full(X.shape[1] - 1, -1), -np.inf]
     ub = np.r_[np.zeros(X.shape[1] - 1), np.inf]
     bounds = Bounds(lb, ub)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression(penalty="l2").fit(X, y, bounds=bounds)
 
 
-def test_contraints():
+@pytest.mark.skip(reason="these issues are dalt internally within scipy")
+def test_constraints():
     X, y = load_breast_cancer(return_X_y=True)
 
     lb = np.array([0.0])
@@ -123,14 +119,14 @@ def test_contraints():
     A = np.zeros((1, X.shape[1] + 1))
     A[0, :2] = np.array([-1, 1])
 
-    with raises(TypeError):
+    with pytest.raises(TypeError):
         ConstrainedLogisticRegression().fit(X, y, constraints=[A, lb, ub])
 
     lb = np.array([0.0])
     ub = np.array([0.5])
     constraints = LinearConstraint(A, lb, ub)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
     lb = np.array([0.0])
@@ -138,7 +134,7 @@ def test_contraints():
     A = np.zeros((1, X.shape[1]))
     constraints = LinearConstraint(A, lb, ub)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
     lb = np.array([0.0, 0.2])
@@ -146,7 +142,7 @@ def test_contraints():
     A = np.zeros((1, X.shape[1] + 1))
     constraints = LinearConstraint(A, lb, ub)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         ConstrainedLogisticRegression().fit(X, y, constraints=constraints)
 
 
@@ -172,7 +168,7 @@ def test_predict_breast_cancer():
             assert np.mean(pred == y) > 0.93
 
             probabilities = clf.predict_proba(X)
-            assert probabilities.sum(axis=1) == approx(np.ones(X.shape[0]))
+            assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
 
             pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
             assert np.mean(pred == y) > 0.9
@@ -202,7 +198,7 @@ def test_predict_breast_cancer_no_intercept():
             assert np.mean(pred == y) > 0.93
 
             probabilities = clf.predict_proba(X)
-            assert probabilities.sum(axis=1) == approx(np.ones(X.shape[0]))
+            assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
 
             pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
             assert np.mean(pred == y) > 0.9
@@ -240,7 +236,7 @@ def test_predict_breast_cancer_bounds_constraints():
             assert np.mean(pred == y) > 0.93
 
             probabilities = clf.predict_proba(X)
-            assert probabilities.sum(axis=1) == approx(np.ones(X.shape[0]))
+            assert probabilities.sum(axis=1) == pytest.approx(np.ones(X.shape[0]))
 
             pred = clf.classes_[np.argmax(clf.predict_log_proba(X), axis=1)]
             assert np.mean(pred == y) > 0.9
@@ -262,7 +258,7 @@ def test_warm_start():
         clf.fit(X, y)
         score2 = clf.score(X, y)
 
-        assert score1 == approx(score2, rel=1e-1)
+        assert score1 == pytest.approx(score2, rel=1e-1)
 
 
 def test_class_weight():

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -7,7 +7,6 @@ from scipy.special import expit
 from sklearn.linear_model import LogisticRegression
 
 from clogistic import ConstrainedLogisticRegression
-from tests.conftest import fake_data
 
 
 def bounds_and_constraints(


### PR DESCRIPTION
# Major upgrade to Clogistic

- **Version bump with no backward compatability: 0.4.0** 
- Upgrade minimal versions to 2024 packages (`python>=3.10, numpy>=1.24, sklearn>=1.2.0` etc.)
- Rename `LogisticRegression` to `ConstrainedLogisticRegression` for better distinction and to allow importing both in same module
- Rename "L-BFGS-B" to "lbfgs" to align with `LogisticRegression`
- add `to_logistic_regression` method that converts model to `LogisticRegression` to support standard `joblib` dumping and loading,  and production-deployment with standard sklearn tools (for example `sagemaker.sklearn`)
- Make `ConstrainedLogisticRegression` inherit directly from `LogisticRegression`, so only `.fit` method needs to be re-implemented
- More usage of internal `scikit-learn` validations, utilities and functions
- Support `scikit-learn` refactoring in 1.6, including new `sklearn.utils.validation.validate_data`, and:
- Fix [Issue #6](https://github.com/guillermo-navas-palencia/clogistic/issues/6) (see `scikit-learn` [PR#27544](https://github.com/scikit-learn/scikit-learn/pull/27544))
- Refactor tests using `pytest` fixtures
- Add tests for dataframes
- Refactor with `black`, type hints, etc


### Tested on
```
python==3.10.0
cvxpy==1.4.0
numpy==1.26.4
pandas==1.5.3
scikit-learn==1.2.0
scipy==1.12.0
```

```
python==3.12.11
cvxpy==1.5.3
numpy==2.3.2
pandas==2.3.1
scikit-learn==1.7.1
scipy==1.16.0
```